### PR TITLE
V2 dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+./local-environments

--- a/README.md
+++ b/README.md
@@ -97,9 +97,11 @@ To create different environments (prod, uat, dev), it is assumed that they same 
 |                              module                              | Description                                                                                                             |
 | :--------------------------------------------------------------: | :---------------------------------------------------------------------------------------------------------------------- |
 |         [common-config](modules/common-config/README.md)         | Contains common configuration that can be used between other modules, such as IDs for computing shape, os versions, etc |
+|                 [vault](modules/vault/README.md)                 | Create Vault and manages keys                                                                                           |
 |   [file-storage-systme](modules/file-storage-system/README.md)   | Create a file storage system with exports, export paths and mount targets in a given VCN                                |
 |              [identity](modules/identity/README.md)              | IAM management, compartment and policies for creating users, groups, compartments, and policies                         |
 |             [instances](modules/instances/README.md)             | Create compute instances and attach a network security group id in a given subnets and VCN                              |
+|               [volumes](modules/volumes/README.md)               | Create Volumes, Backup Policy and manages volumes attachments                                                           |
 |            [kuberentes](modules/kubernetes/README.md)            | Creates k8s cluster and node pools in the given VCN                                                                     |
 |         [load-balancer](modules/load-balancer/README.md)         | WIP - Not ready                                                                                                         |
 |                 [mysql](modules/mysql/README.md)                 | Creates MYSQL Database in a given VCN                                                                                   |

--- a/modules/common-config/output.tf
+++ b/modules/common-config/output.tf
@@ -22,3 +22,44 @@ output "instance_config" {
     }
   }
 }
+
+output "vault_constants" {
+  value = {
+    vault_types = {
+      default = "DEFAULT"
+      private = "VIRTUAL_PRIVATE"
+    }
+
+    protect_mode = {
+      hardware = "HSM"
+      software = "SOFTWARE"
+    }
+    
+    key_shapes = {
+      aes = {
+        name = "AES"
+        length = {
+          "16" = 16
+          "24" = 24
+          "32" = 32
+        }
+      }
+      rsa = {
+        name = "RSA"
+        length = {
+          "256" = 256
+          "384" = 384
+          "512" = 512
+        }
+      }
+      ecdsa = {
+        name = "ECDSA"
+        length = {
+          "32" = 32
+          "48" = 48
+          "66" = 66
+        }
+      }
+    }
+  }
+}

--- a/modules/common-config/output.tf
+++ b/modules/common-config/output.tf
@@ -13,13 +13,14 @@ output "instance_config" {
     }
 
     shapes = {
-      micro          = "VM.Standard.E2.1.Micro"
-      standard-ocp1  = "VM.Standard2.1"
-      standard-ocp2  = "VM.Standard2.2"
-      standard-ocp4  = "VM.Standard2.4"
-      standard-ocp8  = "VM.Standard2.8"
-      standard-ocp16 = "VM.Standard2.16"
-      standard-ocp24 = "VM.Standard2.24"
+      micro            = "VM.Standard.E2.1.Micro"
+      standard-ocp1    = "VM.Standard2.1"
+      standard-ocp2    = "VM.Standard2.2"
+      standard-ocp4    = "VM.Standard2.4"
+      standard-ocp8    = "VM.Standard2.8"
+      standard-ocp16   = "VM.Standard2.16"
+      standard-ocp24   = "VM.Standard2.24"
+      standard-e3-flex = "VM.Standard.E3.Flex"
     }
   }
 }

--- a/modules/common-config/output.tf
+++ b/modules/common-config/output.tf
@@ -9,6 +9,7 @@ output "instance_config" {
       ubuntu_20                   = "ocid1.image.oc1.me-jeddah-1.aaaaaaaay5jjjjj5bv2hh5553oi2ljo7nc36dxhx75sarcecs5ozlu374lja"
       oracle_linux_7_8_2020_09_23 = "ocid1.image.oc1.me-jeddah-1.aaaaaaaaaqsxujxurzktxkwx4umh3k7vawylcpi6qibvduvx4cuf5vctajea"
       oracle_linux_7_9_2021_01_12 = "ocid1.image.oc1.me-jeddah-1.aaaaaaaawnlta4ua2sytgjsdd7asdb4naqbgpbiycpcmicdpi3jufh2qajuq"
+      oracle_linux_8_4_2021_10_20 = "ocid1.image.oc1.me-jeddah-1.aaaaaaaag74rit3jqqu4q4vjeabrvmhg767s4kcazzyj5nufvo3joshrlsta"
     }
 
     shapes = {

--- a/modules/common-config/output.tf
+++ b/modules/common-config/output.tf
@@ -34,7 +34,7 @@ output "vault_constants" {
       hardware = "HSM"
       software = "SOFTWARE"
     }
-    
+
     key_shapes = {
       aes = {
         name = "AES"

--- a/modules/file-storage-system/variables.tf
+++ b/modules/file-storage-system/variables.tf
@@ -5,8 +5,8 @@ variable "fss" {
     exports = map(object({
       path = string # The path to export
       options = map(object({
-        source    = string
-        access    = string
+        source = string
+        access = string
         #TODO : Fix this check instances module for example of fix
         optionals = any # this must be a map(any) however, due to a bug, it has to be marked as any
         # The followings are the keys for the optionals with defaults in brackets

--- a/modules/file-storage-system/variables.tf
+++ b/modules/file-storage-system/variables.tf
@@ -7,6 +7,7 @@ variable "fss" {
       options = map(object({
         source    = string
         access    = string
+        #TODO : Fix this check instances module for example of fix
         optionals = any # this must be a map(any) however, due to a bug, it has to be marked as any
         # The followings are the keys for the optionals with defaults in brackets
         # require_privileged_source_port = bool ("true")

--- a/modules/identity/main.tf
+++ b/modules/identity/main.tf
@@ -120,3 +120,13 @@ resource "oci_identity_policy" "policies" {
 
   depends_on = [local.depends_on]
 }
+
+
+## IdP Mapping
+resource "oci_identity_idp_group_mapping" "idp_group_mapping" {
+  for_each = var.identity_group_mapping
+
+  group_id             = each.value.oci_group_id
+  identity_provider_id = each.value.idp_ocid
+  idp_group_name       = each.value.idp_group_name
+}

--- a/modules/identity/output.tf
+++ b/modules/identity/output.tf
@@ -1,3 +1,11 @@
 output "compartments" {
   value = oci_identity_compartment.compartments
 }
+
+output "groups" {
+  value = oci_identity_group.groups
+}
+
+output "service_accounts_groups" {
+  value = oci_identity_group.service_accounts_groups
+}

--- a/modules/identity/variables.tf
+++ b/modules/identity/variables.tf
@@ -24,6 +24,22 @@ variable "enable_delete" {
   description = "wether to allow this compartement to be deleted if there are resources"
 }
 
+variable "identity_group_mapping" {
+  type = map(object({
+    idp_group_name = string
+    oci_group_id   = string
+    idp_ocid       = string
+  }))
+  default     = {}
+  description = <<EOF
+  This is optional. 
+  Map of group mapping between idp groups and oci groups
+    idp_group_name  : the name of idp group
+    oci_group_id    :  ocid group
+    idp_ocid        : the OCID of the IDP integration.
+  EOF
+}
+
 variable "memberships" {
   type        = map(set(string))
   default     = {}

--- a/modules/instances/README.md
+++ b/modules/instances/README.md
@@ -7,8 +7,11 @@ The module iterates over a list of instances as input, and create them. Check `v
 
 Each object in the input list represent an instance that can have its own configuration, such as which compartment, subnet it belongs to, or which security group is attached to.
 
+Using this module you can attach multiple VNICs to your instance. Moreover, you can assign secondary IP (e.g as floating IP) to each of VNIC.
+
+To attach public IP to any private IP you create in this module, refer to `public_ip` module.
+
 ## Limitations
-* The current setup allows an instance to be part of one subnet. Attaching an instance to multiple network interface is not yet supported in this module.
 * Advance Configuration of the instance is not yet possible using this module. The only configuration acceptable are the ones defined in `variables.tf`.
 
 ## Examples
@@ -55,6 +58,33 @@ locals {
         network_sgs_ids = [
           "ocixxxxxx.xxxxxx.xxxxx", "ocixxxxxx.xxxxxx.xxxxx",
         ]
+        primary_vnic = {
+          primary_ip = "192.168.100.12"
+          secondary_ips = {
+            "floating_ip_1" = {
+              name       = "floating IP"
+              ip_address = "192.168.100.200"
+            }
+          }
+        }
+      }
+      secondary_vnics = {
+        "network_a_vnic" = {
+          name       = "VNIC in Network A"
+          primary_ip = "192.168.130.12"
+          subnet_id  = "ocid1.subnet.oc1.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          nsg_ids    = []
+          optionals = {
+            skip_source_dest_check = true
+            hostname_label         = "vnic_2"
+          }
+          secondary_ips = {
+            "floating_ip" = {
+              name       = "Floating IP in Network A"
+              ip_address = "192.168.130.200"
+            }
+          }
+        }
       }
     }
 }

--- a/modules/instances/README.md
+++ b/modules/instances/README.md
@@ -17,6 +17,7 @@ To create 2 instances:
 locals { 
   instances = {
     "prod-jumpbox" = {
+      name                     = "jumpbox-production"
       availability_domain_name = "ocixxxxxx.xxxxxx.xxxxx"
       fault_domain_name        = "ocixxxxxx.xxxxxx.xxxxx"
       compartment_id           = "ocixxxxxx.xxxxxx.xxxxx"
@@ -37,6 +38,7 @@ locals {
     }
     
     "dev-jumpbox" = {
+      name                     = "jumpbox-development"
       availability_domain_name = "ocixxxxxx.xxxxxx.xxxxx"
       fault_domain_name        = "ocixxxxxx.xxxxxx.xxxxx"
       compartment_id           = "ocixxxxxx.xxxxxx.xxxxx"

--- a/modules/instances/README.md
+++ b/modules/instances/README.md
@@ -37,7 +37,12 @@ locals {
         network_sgs_ids = [
           "ocixxxxxx.xxxxxx.xxxxx", "ocixxxxxx.xxxxxx.xxxxx",
         ]
+        primary_vnic = {
+          primary_ip = ""
+          secondary_ips = {}
+        }
       }
+      secondary_vnics = {}
     }
     
     "dev-jumpbox" = {
@@ -74,10 +79,8 @@ locals {
           primary_ip = "192.168.130.12"
           subnet_id  = "ocid1.subnet.oc1.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
           nsg_ids    = []
-          optionals = {
-            skip_source_dest_check = true
-            hostname_label         = "vnic_2"
-          }
+          skip_source_dest_check = true
+          hostname_label         = "vnic_2"
           secondary_ips = {
             "floating_ip" = {
               name       = "Floating IP in Network A"

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -92,8 +92,8 @@ resource "oci_core_vnic_attachment" "secondary_vnic_attachment" {
     private_ip                = each.value.vnic.primary_ip == "" ? null : each.value.vnic.primary_ip
     nsg_ids                   = each.value.vnic.nsg_ids
     subnet_id                 = each.value.vnic.subnet_id
-    hostname_label            = lookup(each.value.vnic.optionals, "hostname_label", null)
-    skip_source_dest_check    = lookup(each.value.vnic.optionals, "skip_source_dest_check", false)
+    hostname_label            = each.value.vnic.hostname_label
+    skip_source_dest_check    = each.value.vnic.skip_source_dest_check
   }
 
   instance_id = oci_core_instance.instances[each.value.instance_key].id

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -5,7 +5,7 @@ resource "oci_core_instance" "instances" {
   fault_domain         = each.value.fault_domain_name
   compartment_id       = each.value.compartment_id
   shape                = each.value.config.shape
-  display_name         = each.key
+  display_name         = each.value.name
   preserve_boot_volume = true
   state                = each.value.state
   metadata = {

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -1,12 +1,36 @@
 locals {
   flattened_primary_vnic_secondry_ips = flatten([
-    for k, instance in var.instances: [
-      for kk, secondry_ip in instance.config.primary_vnic.secondry_ips: {
-        instance_key = k
+    for k, instance in var.instances : [
+      for kk, secondry_ip in instance.config.primary_vnic.secondry_ips : {
+        instance_key    = k
         secondry_ip_key = kk
-        name         = secondry_ip.name
-        ip_address   = secondry_ip.ip_address
+        name            = secondry_ip.name
+        ip_address      = secondry_ip.ip_address
       }
+    ]
+  ])
+
+  flattened_secondary_vnics = flatten([
+    for instance_key, instance in var.instances : [
+      for vnic_key, vnic in instance.secondary_vnics : {
+        instance_key = instance_key
+        vnic_key     = vnic_key
+        vnic         = vnic
+      }
+    ]
+  ])
+
+  flattened_secondary_vnic_secondary_ips = flatten([
+    for instance_key, instance in var.instances : [
+      for vnic_key, vnic in instance.secondary_vnics : [
+        for ip_key, secondry_ip in vnic.secondry_ips : {
+          instance_key    = instance_key
+          vnic_key        = vnic_key
+          secondry_ip_key = ip_key
+          name            = secondry_ip.name
+          ip_address      = secondry_ip.ip_address
+        }
+      ]
     ]
   ])
 }
@@ -31,7 +55,7 @@ resource "oci_core_instance" "instances" {
     display_name              = "${each.key}Vnic"
     hostname_label            = each.key
     nsg_ids                   = each.value.config.network_sgs_ids
-    skip_source_dest_check    =  false
+    skip_source_dest_check    = false
     assign_private_dns_record = true
     private_ip                = each.primary_vnic.primary_private_ip
   }
@@ -45,15 +69,39 @@ resource "oci_core_instance" "instances" {
 
 # Getting Primary Initial Private IP ID for instance
 data "oci_core_private_ips" "private_ips_by_ip_address" {
-  for_each = var.instances
+  for_each   = var.instances
   ip_address = oci_core_instance.instances[each.key].private_ip
 }
 
 resource "oci_core_private_ip" "primary_vnic_additional_ips" {
-  for_each = { for v in local.flattened_primary_vnic_secondry_ips: "${v.instance_key}-${v.secondry_ip_key}" => v }
-  
+  for_each = { for v in local.flattened_primary_vnic_secondry_ips : "${v.instance_key}:${v.secondry_ip_key}" => v }
+
   display_name = each.value.name
-  hostname_label = each.value.name
-  ip_address = each.value.ip_address
-  vnic_id = data.oci_core_private_ips.private_ips_by_ip_address[each.value.instance_key].vnic_id
+  ip_address   = each.value.ip_address
+  vnic_id      = data.oci_core_private_ips.private_ips_by_ip_address[each.value.instance_key].vnic_id
+}
+
+# Secondary VNICs
+resource "oci_core_vnic_attachment" "secondary_vnic_attachment" {
+  for_each     = { for v in local.flattened_secondary_vnics : "${v.instance_key}:${v.vnic_key}" => v }
+  display_name = each.key
+  create_vnic_details {
+    assign_private_dns_record = true
+    display_name              = each.value.vnic_key
+    hostname_label            = each.value.vnic.hostname_label
+    nsg_ids                   = each.value.vnic.nsg_ids
+    private_ip                = each.value.vnic.primary_ip
+    skip_source_dest_check    = each.value.vnic.skip_source_dest_check
+    subnet_id                 = each.value.vnic.subnet_id
+  }
+
+  instance_id = oci_core_instance.instances[each.value.instance_key].id
+}
+
+resource "oci_core_private_ip" "secondary_vnic_additional_ips" {
+  for_each = { for v in local.flattened_secondary_vnic_secondary_ips : "${v.instance_key}:${v.vnic_key}:${v.secondry_ip_key}" => v }
+
+  display_name = each.value.name
+  ip_address   = each.value.ip_address
+  vnic_id      = oci_core_vnic_attachment.secondary_vnic_attachment["${v.instance_key}:${v.vnic_key}"].vnic_id
 }

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -1,3 +1,16 @@
+locals {
+  flattened_primary_vnic_secondry_ips = flatten([
+    for k, instance in var.instances: [
+      for kk, secondry_ip in instance.config.primary_vnic.secondry_ips: {
+        instance_key = k
+        secondry_ip_key = kk
+        name         = secondry_ip.name
+        ip_address   = secondry_ip.ip_address
+      }
+    ]
+  ])
+}
+
 resource "oci_core_instance" "instances" {
   for_each = var.instances
 
@@ -6,19 +19,21 @@ resource "oci_core_instance" "instances" {
   compartment_id       = each.value.compartment_id
   shape                = each.value.config.shape
   display_name         = each.value.name
-  preserve_boot_volume = true
+  preserve_boot_volume = lookup(each.value.optionals, "preserve_boot_volume", true)
   state                = each.value.state
   metadata = {
     ssh_authorized_keys = each.value.autherized_keys
   }
 
   create_vnic_details {
-    subnet_id              = each.value.config.subnet.id
-    assign_public_ip       = each.value.config.subnet.prohibit_public_ip_on_vnic == false
-    display_name           = "${each.key}Vnic"
-    hostname_label         = each.key
-    nsg_ids                = each.value.config.network_sgs_ids
-    skip_source_dest_check = false
+    subnet_id                 = each.value.config.subnet.id
+    assign_public_ip          = each.value.config.subnet.prohibit_public_ip_on_vnic == false
+    display_name              = "${each.key}Vnic"
+    hostname_label            = each.key
+    nsg_ids                   = each.value.config.network_sgs_ids
+    skip_source_dest_check    =  false
+    assign_private_dns_record = true
+    private_ip                = each.primary_vnic.primary_private_ip
   }
 
   source_details {
@@ -26,4 +41,19 @@ resource "oci_core_instance" "instances" {
     source_id               = each.value.config.image_id
     boot_volume_size_in_gbs = each.value.volume_size
   }
+}
+
+# Getting Primary Initial Private IP ID for instance
+data "oci_core_private_ips" "private_ips_by_ip_address" {
+  for_each = var.instances
+  ip_address = oci_core_instance.instances[each.key].private_ip
+}
+
+resource "oci_core_private_ip" "primary_vnic_additional_ips" {
+  for_each = { for v in local.flattened_primary_vnic_secondry_ips: "${v.instance_key}-${v.secondry_ip_key}" => v }
+  
+  display_name = each.value.name
+  hostname_label = each.value.name
+  ip_address = each.value.ip_address
+  vnic_id = data.oci_core_private_ips.private_ips_by_ip_address[each.value.instance_key].vnic_id
 }

--- a/modules/instances/output.tf
+++ b/modules/instances/output.tf
@@ -26,7 +26,7 @@ output "instances" {
               ip_address = oci_core_private_ip.secondary_vnic_additional_ips["${ip.instance_key}:${ip.vnic_key}:${ip.secondary_ip_key}"].ip_address
               vnic_id    = oci_core_private_ip.secondary_vnic_additional_ips["${ip.instance_key}:${ip.vnic_key}:${ip.secondary_ip_key}"].vnic_id
               subnet_id  = oci_core_private_ip.secondary_vnic_additional_ips["${ip.instance_key}:${ip.vnic_key}:${ip.secondary_ip_key}"].subnet_id
-            } if ip.vnic_key == vnic.vnic_key
+            } if ip.instance_key == k
           }
         } if vnic.instance_key == k
       }

--- a/modules/instances/output.tf
+++ b/modules/instances/output.tf
@@ -1,31 +1,40 @@
 output "instances" {
   value = {
     for k, instance in oci_core_instance.instances : k => {
-      public_ip  = instance.public_ip
-      private_ip = instance.private_ip
       primary_vnic = {
-        primary_ip = [for ip in data.oci_core_private_ips.primary_vnic_primary_private_ip[k].private_ips : ip if ip.is_primary][0]
+        primary_ip = [
+          for ip in data.oci_core_private_ips.primary_vnic_primary_private_ip[k].private_ips : {
+            id         = ip.id
+            ip_address = ip.ip_address
+            vnic_id    = ip.vnic_id
+            subnet_id  = ip.subnet_id
+            public_ip  = instance.public_ip
+          } if ip.is_primary
+        ][0]
         secondary_ips = {
           for ip in local.flattened_primary_vnic_secondary_ips :
           ip.secondary_ip_key => {
             id         = oci_core_private_ip.primary_vnic_additional_ips["${ip.instance_key}:primary_vnic:${ip.secondary_ip_key}"].id
             ip_address = oci_core_private_ip.primary_vnic_additional_ips["${ip.instance_key}:primary_vnic:${ip.secondary_ip_key}"].ip_address
-            vnic_id    = oci_core_private_ip.primary_vnic_additional_ips["${ip.instance_key}:primary_vnic:${ip.secondary_ip_key}"].vnic_id
-            subnet_id  = oci_core_private_ip.primary_vnic_additional_ips["${ip.instance_key}:primary_vnic:${ip.secondary_ip_key}"].subnet_id
           } if ip.instance_key == k
         }
       }
       secondary_vnics = {
         for vnic in local.flattened_secondary_vnics :
         vnic.vnic_key => {
-          primary_ip = [for ip in data.oci_core_private_ips.secondary_vnic_attachment_ips["${vnic.instance_key}:${vnic.vnic_key}"].private_ips : ip if ip.is_primary][0]
+          primary_ip = [
+            for ip in data.oci_core_private_ips.secondary_vnic_attachment_ips["${vnic.instance_key}:${vnic.vnic_key}"].private_ips : {
+              id         = ip.id
+              ip_address = ip.ip_address
+              vnic_id    = ip.vnic_id
+              subnet_id  = ip.subnet_id
+            } if ip.is_primary
+          ][0]
           secondary_ips = {
             for ip in local.flattened_secondary_vnic_secondary_ips :
             ip.secondary_ip_key => {
               id         = oci_core_private_ip.secondary_vnic_additional_ips["${ip.instance_key}:${ip.vnic_key}:${ip.secondary_ip_key}"].id
               ip_address = oci_core_private_ip.secondary_vnic_additional_ips["${ip.instance_key}:${ip.vnic_key}:${ip.secondary_ip_key}"].ip_address
-              vnic_id    = oci_core_private_ip.secondary_vnic_additional_ips["${ip.instance_key}:${ip.vnic_key}:${ip.secondary_ip_key}"].vnic_id
-              subnet_id  = oci_core_private_ip.secondary_vnic_additional_ips["${ip.instance_key}:${ip.vnic_key}:${ip.secondary_ip_key}"].subnet_id
             } if ip.instance_key == k
           }
         } if vnic.instance_key == k

--- a/modules/instances/output.tf
+++ b/modules/instances/output.tf
@@ -3,6 +3,33 @@ output "instances" {
     for k, instance in oci_core_instance.instances : k => {
       public_ip  = instance.public_ip
       private_ip = instance.private_ip
+      primary_vnic = {
+        primary_ip = [for ip in data.oci_core_private_ips.primary_vnic_primary_private_ip[k].private_ips : ip if ip.is_primary][0]
+        secondary_ips = {
+          for ip in local.flattened_primary_vnic_secondary_ips :
+          ip.secondary_ip_key => {
+            id         = oci_core_private_ip.primary_vnic_additional_ips["${ip.instance_key}:primary_vnic:${ip.secondary_ip_key}"].id
+            ip_address = oci_core_private_ip.primary_vnic_additional_ips["${ip.instance_key}:primary_vnic:${ip.secondary_ip_key}"].ip_address
+            vnic_id    = oci_core_private_ip.primary_vnic_additional_ips["${ip.instance_key}:primary_vnic:${ip.secondary_ip_key}"].vnic_id
+            subnet_id  = oci_core_private_ip.primary_vnic_additional_ips["${ip.instance_key}:primary_vnic:${ip.secondary_ip_key}"].subnet_id
+          } if ip.instance_key == k
+        }
+      }
+      secondary_vnics = {
+        for vnic in local.flattened_secondary_vnics :
+        vnic.vnic_key => {
+          primary_ip = [for ip in data.oci_core_private_ips.secondary_vnic_attachment_ips["${vnic.instance_key}:${vnic.vnic_key}"].private_ips : ip if ip.is_primary][0]
+          secondary_ips = {
+            for ip in local.flattened_secondary_vnic_secondary_ips :
+            ip.secondary_ip_key => {
+              id         = oci_core_private_ip.secondary_vnic_additional_ips["${ip.instance_key}:${ip.vnic_key}:${ip.secondary_ip_key}"].id
+              ip_address = oci_core_private_ip.secondary_vnic_additional_ips["${ip.instance_key}:${ip.vnic_key}:${ip.secondary_ip_key}"].ip_address
+              vnic_id    = oci_core_private_ip.secondary_vnic_additional_ips["${ip.instance_key}:${ip.vnic_key}:${ip.secondary_ip_key}"].vnic_id
+              subnet_id  = oci_core_private_ip.secondary_vnic_additional_ips["${ip.instance_key}:${ip.vnic_key}:${ip.secondary_ip_key}"].subnet_id
+            } if ip.vnic_key == vnic.vnic_key
+          }
+        } if vnic.instance_key == k
+      }
     }
   }
 }

--- a/modules/instances/output.tf
+++ b/modules/instances/output.tf
@@ -1,6 +1,7 @@
 output "instances" {
   value = {
     for k, instance in oci_core_instance.instances : k => {
+      id           = k.id
       primary_vnic = {
         primary_ip = [
           for ip in data.oci_core_private_ips.primary_vnic_primary_private_ip[k].private_ips : {

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -1,7 +1,7 @@
 
 variable "instances" {
   type = map(object({
-    name = string
+    name                     = string
     availability_domain_name = string
     fault_domain_name        = string
     compartment_id           = string

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -1,6 +1,7 @@
 
 variable "instances" {
   type = map(object({
+    name = string
     availability_domain_name = string
     fault_domain_name        = string
     compartment_id           = string

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -33,13 +33,12 @@ variable "instances" {
       })
     })
     secondary_vnics = map(object({
-      name       = string
-      primary_ip = string # Leave empty for dynamic allocation
-      subnet_id  = string
-      nsg_ids    = list(string)
-      optionals  = map(any)
-      # skip_source_dest_check = bool (false)
-      # hostname_label         = string (null)
+      name                   = string
+      primary_ip             = string # Leave empty for dynamic allocation
+      subnet_id              = string
+      nsg_ids                = list(string)
+      skip_source_dest_check = bool
+      hostname_label         = string
       secondary_ips = map(object({
         name       = string
         ip_address = string
@@ -65,7 +64,7 @@ variable "instances" {
         id                         : ocid of the subnet
         prohibit_public_ip_on_vnic : whether to create public IP or not if located in public subnet, set to false if not
       primary_vnic : object for primary VNIC configuration
-        primary_ip   : custom initial IP. If left empty, oci will create IP dynamically.
+        primary_ip    : custom initial IP. If left empty, oci will create IP dynamically.
         secondary_ips : map of objects for secondary IP configuration
           name         : the name of IP
           ip_address   : custom IP that must be in the same subnet above of VNIC. If left empty, oci will create IP dynamically
@@ -74,9 +73,8 @@ variable "instances" {
       primary_ip =  custom initial IP. If left empty, oci will create IP dynamically.
       subnet_id  = subnet id for creating the VNIC in
       nsg_ids    = list network security groups ids to be applied to the VNIC
-      optionals  = set of key/value map that can be used for customise default values.
-        skip_source_dest_check = bool (false)
-        hostname_label         = string (null)
+      skip_source_dest_check = bool (false)
+      hostname_label         = string (null)
       secondary_ips = map of objects for secondary IP configuration
         name       = string
         ip_address = string

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -1,4 +1,11 @@
 
+locals {
+  default_primary_config = {
+    primary_ip   = ""
+    secondry_ips = {}
+  }
+}
+
 variable "instances" {
   type = map(object({
     name                     = string
@@ -20,11 +27,22 @@ variable "instances" {
         primary_ip = string # Leave empty if no need for it
         secondry_ips = map(object({
           # Use oci_core_private_ip to attach private ip to existing primary vnic
-          name = string
+          name       = string
           ip_address = string # must be in the same subnet
         }))
       })
     })
+    secondary_vnics = map(object({
+      primary_ip             = string
+      subnet_id              = string
+      nsg_ids                = list(string)
+      skip_source_dest_check = bool
+      hostname_label         = string
+      secondry_ips = map(object({
+        name       = string
+        ip_address = string
+      }))
+    }))
     optionals = map(any)
     # preserve_boot_volume =  bool (true)
   }))

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -20,6 +20,7 @@ variable "instances" {
   }))
   description = <<EOF
     map of objects that represent instances to create. The key name is the instance name that is used for FQDN
+    name                    : the name of instance
     availability_domain_name: the name of the availability domain to create instance in
     fault_domain_name       : the name of the fault domain in the availability domain to create instance in
     compartment_id          : ocid of the compartment

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -24,17 +24,16 @@ variable "instances" {
         prohibit_public_ip_on_vnic = bool
       })
       primary_vnic = object({
-        primary_ip = string # Leave empty if no need for it
+        primary_ip = string
         secondary_ips = map(object({
-          # Use oci_core_private_ip to attach private ip to existing primary vnic
           name       = string
-          ip_address = string # must be in the same subnet
+          ip_address = string
         }))
       })
     })
     secondary_vnics = map(object({
       name                   = string
-      primary_ip             = string # Leave empty for dynamic allocation
+      primary_ip             = string
       subnet_id              = string
       nsg_ids                = list(string)
       skip_source_dest_check = bool

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -1,8 +1,8 @@
 
 locals {
   default_primary_config = {
-    primary_ip   = ""
-    secondry_ips = {}
+    primary_ip    = ""
+    secondary_ips = {}
   }
 }
 
@@ -25,7 +25,7 @@ variable "instances" {
       })
       primary_vnic = object({
         primary_ip = string # Leave empty if no need for it
-        secondry_ips = map(object({
+        secondary_ips = map(object({
           # Use oci_core_private_ip to attach private ip to existing primary vnic
           name       = string
           ip_address = string # must be in the same subnet
@@ -33,12 +33,14 @@ variable "instances" {
       })
     })
     secondary_vnics = map(object({
-      primary_ip             = string
-      subnet_id              = string
-      nsg_ids                = list(string)
-      skip_source_dest_check = bool
-      hostname_label         = string
-      secondry_ips = map(object({
+      name       = string
+      primary_ip = string # Leave empty for dynamic allocation
+      subnet_id  = string
+      nsg_ids    = list(string)
+      optionals  = map(any)
+      # skip_source_dest_check = bool (false)
+      # hostname_label         = string (null)
+      secondary_ips = map(object({
         name       = string
         ip_address = string
       }))
@@ -64,9 +66,20 @@ variable "instances" {
         prohibit_public_ip_on_vnic : whether to create public IP or not if located in public subnet, set to false if not
       primary_vnic : object for primary VNIC configuration
         primary_ip   : custom initial IP. If left empty, oci will create IP dynamically.
-        secondry_ips : map of objects for secondry IP configuration
+        secondary_ips : map of objects for secondary IP configuration
           name         : the name of IP
           ip_address   : custom IP that must be in the same subnet above of VNIC. If left empty, oci will create IP dynamically
+    secondary_vnics: map of object for secondary VNIC configuration
+      name       = the name of VNIC
+      primary_ip =  custom initial IP. If left empty, oci will create IP dynamically.
+      subnet_id  = subnet id for creating the VNIC in
+      nsg_ids    = list network security groups ids to be applied to the VNIC
+      optionals  = set of key/value map that can be used for customise default values.
+        skip_source_dest_check = bool (false)
+        hostname_label         = string (null)
+      secondary_ips = map of objects for secondary IP configuration
+        name       = string
+        ip_address = string
     optionals : set of key/value map that can be used for customise default values.
       preserve_boot_volume  : whether to keep boot volume after delete or not
   EOF

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -16,7 +16,17 @@ variable "instances" {
         id                         = string,
         prohibit_public_ip_on_vnic = bool
       })
+      primary_vnic = object({
+        primary_ip = string # Leave empty if no need for it
+        secondry_ips = map(object({
+          # Use oci_core_private_ip to attach private ip to existing primary vnic
+          name = string
+          ip_address = string # must be in the same subnet
+        }))
+      })
     })
+    optionals = map(any)
+    # preserve_boot_volume =  bool (true)
   }))
   description = <<EOF
     map of objects that represent instances to create. The key name is the instance name that is used for FQDN
@@ -27,14 +37,19 @@ variable "instances" {
     volume_size             : the initial boot volume size in GB
     state                   : RUNNING or STOPPED
     autherized_keys         : single string containing the SSH-RSA keys seperated by \n
-    config = object of instance configuration
+    config                  : object of instance configuration
       shape           : name of the VM shape to be used
       image_id        : ocid of the boot image
       network_sgs_ids : list network security groups ids to be applied to the main interface
-      subnet = object for the subnet configuration
+      subnet          : object for the subnet configuration
         id                         : ocid of the subnet
         prohibit_public_ip_on_vnic : whether to create public IP or not if located in public subnet, set to false if not
-      })
-    })
+      primary_vnic : object for primary VNIC configuration
+        primary_ip   : custom initial IP. If left empty, oci will create IP dynamically.
+        secondry_ips : map of objects for secondry IP configuration
+          name         : the name of IP
+          ip_address   : custom IP that must be in the same subnet above of VNIC. If left empty, oci will create IP dynamically
+    optionals : set of key/value map that can be used for customise default values.
+      preserve_boot_volume  : whether to keep boot volume after delete or not
   EOF
 }

--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -31,6 +31,7 @@ module "kubernetes" {
       availability_domain   = "ocixxxxxx.xxxxxx.xxxxx"
       subnet_id             = "ocixxxxxx.xxxxxx.xxxxx"
       shape                 = "VM-XXXXXx"
+      volume_size_in_gbs    = 500
       size                  = 2
       k8s_version           = "v1.18.10"
       image_id              = "ocixxxxxx.xxxxxx.xxxxx"
@@ -45,6 +46,7 @@ module "kubernetes" {
       availability_domain = "ocixxxxxx.xxxxxx.xxxxx"
       subnet_id           = "ocixxxxxx.xxxxxx.xxxxx"
       shape               = "VM-XXXXXx"
+      volume_size_in_gbs  = 50
       size                = 4
       k8s_version         = "v1.18.10"
       image_id            = "ocixxxxxx.xxxxxx.xxxxx"

--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -18,7 +18,7 @@ module "kubernetes" {
   cluster_name                = "kubernetes"
   enable_kubernetes_dashboard = false
   lb_subnet_ids               = ["ocixxxxxx.xxxxxx.xxxxx", "ocixxxxxx.xxxxxx.xxxxx"]
-  cluster_k8s_version                 = "v1.18.10"
+  cluster_k8s_version         = "v1.18.10"
   node_pools                  = {
     "node-pool-a" = {
       compartment_id        = "ocixxxxxx.xxxxxx.xxxxx"
@@ -27,7 +27,7 @@ module "kubernetes" {
       subnet_id             = "ocixxxxxx.xxxxxx.xxxxx"
       shape                 = "VM-XXXXXx"
       size                  = 2
-      node_pool_k8s_version = "v1.18.10"
+      k8s_version           = "v1.18.10"
       image_id              = "ocixxxxxx.xxxxxx.xxxxx"
       labels = {
         "my-label" : "k8s-label"
@@ -41,7 +41,7 @@ module "kubernetes" {
       subnet_id           = "ocixxxxxx.xxxxxx.xxxxx"
       shape               = "VM-XXXXXx"
       size                = 4
-      node_pool_k8s_version = "v1.18.10"
+      k8s_version         = "v1.18.10"
       image_id            = "ocixxxxxx.xxxxxx.xxxxx"
       labels = {
         "my-label" : "k8s-label"

--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -18,16 +18,17 @@ module "kubernetes" {
   cluster_name                = "kubernetes"
   enable_kubernetes_dashboard = false
   lb_subnet_ids               = ["ocixxxxxx.xxxxxx.xxxxx", "ocixxxxxx.xxxxxx.xxxxx"]
-  k8s_version                 = "v1.18.10"
+  cluster_k8s_version                 = "v1.18.10"
   node_pools                  = {
     "node-pool-a" = {
-      compartment_id      = "ocixxxxxx.xxxxxx.xxxxx"
-      ssh_public_key      = "ssh-rsa xxxxxxxxxx"
-      availability_domain = "ocixxxxxx.xxxxxx.xxxxx"
-      subnet_id           = "ocixxxxxx.xxxxxx.xxxxx"
-      shape               = "VM-XXXXXx"
-      size                = 2
-      image_id            = "ocixxxxxx.xxxxxx.xxxxx"
+      compartment_id        = "ocixxxxxx.xxxxxx.xxxxx"
+      ssh_public_key        = "ssh-rsa xxxxxxxxxx"
+      availability_domain   = "ocixxxxxx.xxxxxx.xxxxx"
+      subnet_id             = "ocixxxxxx.xxxxxx.xxxxx"
+      shape                 = "VM-XXXXXx"
+      size                  = 2
+      node_pool_k8s_version = "v1.18.10"
+      image_id              = "ocixxxxxx.xxxxxx.xxxxx"
       labels = {
         "my-label" : "k8s-label"
       }
@@ -40,6 +41,7 @@ module "kubernetes" {
       subnet_id           = "ocixxxxxx.xxxxxx.xxxxx"
       shape               = "VM-XXXXXx"
       size                = 4
+      node_pool_k8s_version = "v1.18.10"
       image_id            = "ocixxxxxx.xxxxxx.xxxxx"
       labels = {
         "my-label" : "k8s-label"

--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -7,6 +7,11 @@ Using this module, you are limited to one a cluster, to create multiple clusters
 ## Important node about updating node pools shapes
 When the node pool configuration is updated, the existing worker nodes will keep their old shape, however, any newly created node will have the newest configurations. This is the same behaviour when done via Oracle Console.
 
+## Using Flex Shapes
+You have the options to use AMD flex shaeps. Just set `flex_shape_config` key in `node_pools` varible per nood pool. The variable `flex_shape_config` should have the following two keys `ocpus` and `memory_in_gbs`. See example below.
+
+Note that, Flex Shape works only with AMD shape `VM.Standard.E3.Flex` and `VM.Standard.E4.Flex`. 
+
 ## Example
 Creating a cluster with 2 node pools
 ```h
@@ -43,6 +48,10 @@ module "kubernetes" {
       size                = 4
       k8s_version         = "v1.18.10"
       image_id            = "ocixxxxxx.xxxxxx.xxxxx"
+      flex_shape_config = {
+        ocpus         = 4
+        memory_in_gbs = 64
+      }
       labels = {
         "my-label" : "k8s-label"
       }

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -39,8 +39,9 @@ resource "oci_containerengine_node_pool" "node_pool" {
   }
 
   node_source_details {
-    image_id    = each.value.image_id
-    source_type = "IMAGE"
+    image_id                = each.value.image_id
+    source_type             = "IMAGE"
+    boot_volume_size_in_gbs = each.value.boot_volume_size_in_gbs
   }
 
   dynamic "node_shape_config" {

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -2,7 +2,7 @@ resource "oci_containerengine_cluster" "cluster" {
   compartment_id     = var.compartment_id
   name               = var.cluster_name
   vcn_id             = var.vcn_id
-  kubernetes_version = var.k8s_version
+  kubernetes_version = var.cluster_k8s_version
 
   options {
     add_ons {
@@ -18,7 +18,7 @@ resource "oci_containerengine_node_pool" "node_pool" {
 
   cluster_id         = oci_containerengine_cluster.cluster.id
   compartment_id     = each.value.compartment_id
-  kubernetes_version = var.k8s_version
+  kubernetes_version = each.value.node_pool_k8s_version
   name               = "${each.key}-node-pool"
   node_shape         = each.value.shape
   ssh_public_key     = each.value.ssh_public_key

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -42,4 +42,12 @@ resource "oci_containerengine_node_pool" "node_pool" {
     image_id    = each.value.image_id
     source_type = "IMAGE"
   }
+
+  dynamic "node_shape_config" {
+    for_each = length(each.value.flex_shape_config) == 2 ? [1] : []
+    content {
+      memory_in_gbs = each.value.flex_shape_config.memory_in_gbs
+      ocpus         = each.value.flex_shape_config.ocpus
+    }
+  }
 }

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -18,7 +18,7 @@ resource "oci_containerengine_node_pool" "node_pool" {
 
   cluster_id         = oci_containerengine_cluster.cluster.id
   compartment_id     = each.value.compartment_id
-  kubernetes_version = each.value.node_pool_k8s_version
+  kubernetes_version = each.value.k8s_version
   name               = "${each.key}-node-pool"
   node_shape         = each.value.shape
   ssh_public_key     = each.value.ssh_public_key

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -41,7 +41,7 @@ resource "oci_containerengine_node_pool" "node_pool" {
   node_source_details {
     image_id                = each.value.image_id
     source_type             = "IMAGE"
-    boot_volume_size_in_gbs = each.value.boot_volume_size_in_gbs
+    boot_volume_size_in_gbs = each.value.volume_size_in_gbs
   }
 
   dynamic "node_shape_config" {

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -2,7 +2,12 @@ variable "vcn_id" {
   type = string
 }
 
-variable "k8s_version" {
+variable "cluster_k8s_version" {
+  type    = string
+  default = "v1.17.9"
+}
+
+variable "node_pool_k8s_version" {
   type    = string
   default = "v1.17.9"
 }

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -33,6 +33,7 @@ variable "node_pools" {
     availability_domain = string
     shape               = string
     size                = number
+    volume_size_in_gbs  = number
     image_id            = string
     labels              = map(string)
     subnet_id           = string
@@ -47,6 +48,7 @@ variable "node_pools" {
     availability_domain: the AD to create nodes in
     shape              : machine/instance shape
     size               : size of disk in GB
+    volume_size_in_gbs : Size of Boot volume in GB per node
     image_id           : ocid of the image
     labels             : map of key/string values to be added to the node during creation
     subnet_id          : ocid of the subnet to create the node in.

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -4,12 +4,7 @@ variable "vcn_id" {
 
 variable "cluster_k8s_version" {
   type    = string
-  default = "v1.17.9"
-}
-
-variable "node_pool_k8s_version" {
-  type    = string
-  default = "v1.17.9"
+  default = "v1.19.15"
 }
 
 variable "compartment_id" {
@@ -41,6 +36,7 @@ variable "node_pools" {
     image_id            = string
     labels              = map(string)
     subnet_id           = string
+    k8s_version         = string
   }))
 
   description = <<EOL
@@ -53,5 +49,6 @@ variable "node_pools" {
     image_id           : ocid of the image
     labels             : map of key/string values to be added to the node during creation
     subnet_id          : ocid of the subnet to create the node in.
+    k8s_version        : set the version of the node pool
   EOL
 }

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -47,7 +47,7 @@ variable "node_pools" {
     ssh_public_key     : string of ssh-rsa keys to be added to the created nodes/workers in the pool
     availability_domain: the AD to create nodes in
     shape              : machine/instance shape
-    size               : size of disk in GB
+    size               : The number of nodes that should be in the node pool.
     volume_size_in_gbs : Size of Boot volume in GB per node
     image_id           : ocid of the image
     labels             : map of key/string values to be added to the node during creation

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -37,6 +37,7 @@ variable "node_pools" {
     labels              = map(string)
     subnet_id           = string
     k8s_version         = string
+    flex_shape_config   = map(string)
   }))
 
   description = <<EOL
@@ -50,5 +51,16 @@ variable "node_pools" {
     labels             : map of key/string values to be added to the node during creation
     subnet_id          : ocid of the subnet to create the node in.
     k8s_version        : set the version of the node pool
+    flex_shape_config  : customize number of ocpus and memory when using Flex Shape
   EOL
+
+
+  validation {
+    condition = alltrue(flatten([
+      for k, v in var.node_pools : [
+        for keys in keys(v.flex_shape_config) : contains(["ocpus", "memory_in_gbs"], keys)
+      ]
+    ]))
+    error_message = "The node_pools.*.flex_shape_config accepts only \"ocpus\", \"memory_in_gbs\"."
+  }
 }

--- a/modules/network/README.md
+++ b/modules/network/README.md
@@ -13,7 +13,7 @@ The module will create a single virtual cloud network, with no subnet by default
 When the VCN is created, the following objects are created by default:
 * DHCP: Used by default for both public and private subnets
 * Internet Gateway (defaultInternetGateway): it is attached to any created public subnet
-* NAT GAteway (defaultNatGateway): It is attached to any created private subnet
+* NAT GAteway (defaultNatGateway): It is attached to any created private subnet (configurable via variable `nat_configuration`)
 * Route Table (defaultRouteTable): if no route table id is passed for a public subnet, this route table is used for the public subnet. The public default route table is configurable using `public_route_table_rules` variable.
 * Private Route Table (defaultPrivateRouteTable): if no route table id is passed for a private subnet, this route table is used for the private subnet. The private default route table is configurable using `private_route_table_rules` variable.
 * Default Public Security List: This list is attached to EVERY public subnet created.
@@ -27,6 +27,9 @@ When the VCN is created, the following objects are created by default:
 ## Note about Route Table and Security List
 * Route Table: the module will use default route table if not route table id is passed during creation of subnet. You can either configure the defaul route tables using `xxxxxx_route_table_rules` variables, or you can set different route table for each subnet you create using `route_table_id` key of the subnet you create.
 * Security List: the module will create defaul subnet list rules, and you can enhance that further by creating your own security list and pass them as IDs to the subnet. You can also use `default_security_list_rules` to specify list of egress ports to the internet for the public and private subnets.
+
+## Note about NAT gateway
+NAT gateway is configurable via `nat_configuration` variable. Traffic can be blocked. When `nat_configuration.block_traffic` is set to true, the route table rule `0.0.0.0/0` via NAT is removed from table.
 
 ## Limitations
 * The module does not support VCN Peering.
@@ -94,6 +97,11 @@ module "network" {
       enable_icpm_from_vcn       = true
       enable_icpm_to_all         = true
     }
+  }
+
+  nat_configuration = {
+    public_ip_id = "oci.xxxxxxxx"
+    block_traffic = true
   }
 }
 ```

--- a/modules/network/README.md
+++ b/modules/network/README.md
@@ -55,11 +55,13 @@ module "network" {
 
   private_subnets = {
     "private-a" = {
+      name              = "private subnet b"
       cidr_block        = "192.168.2.0/24"
       security_list_ids = ["ocixxxxxx.xxxxxx.xxxxx", "ocixxxxxx.xxxxxx.xxxxx"]
       optionals         = {}
     },
     "private-b" = {
+      name              = "private subnet b"
       cidr_block        = "192.168.3.0/24"
       security_list_ids = ["ocixxxxxx.xxxxxx.xxxxx", "ocixxxxxx.xxxxxx.xxxxx"]
       optionals         = {}
@@ -68,6 +70,7 @@ module "network" {
 
   public_subnets = {
     "public" = {
+      name              = "the public subnet"
       cidr_block        = "192.168.3.0/24"
       security_list_ids = ["ocixxxxxx.xxxxxx.xxxxx", "ocixxxxxx.xxxxxx.xxxxx"]
       optionals         = {

--- a/modules/network/README.md
+++ b/modules/network/README.md
@@ -20,8 +20,8 @@ When the VCN is created, the following objects are created by default:
 * Default Private Security List: This list is attached to EVERY private subnet created.
   
 ## Note About Default Security Lists:
-* **Public security list**: By default empty, however, you can use `default_security_list_rules` variable to pass list of ports for egress traffic for tcp and udp to the world. Also you can enable icpm from and to the world as well.
-* **Private security list**: By default empty, however, you can use `default_security_list_rules` variable to pass list of ports for egress traffic for tcp and udp to the world. Also you can enable icpm from the VCN as well and to the world.
+* **Public security list**: By default empty, however, you can use `default_security_list_rules` variable to pass list of ports for ingress and egress traffic for tcp and udp to the world. Also you can enable icpm from and to the world as well.
+* **Private security list**: By default empty, however, you can use `default_security_list_rules` variable to pass list of ports for ingress egress traffic for tcp and udp to the world. Also you can enable icpm from the VCN as well and to the world.
 * It is possible to create another security list and pass its id to the subnet in `public_subnets` and `private_subnets` variables under key `security_list_ids`. The passed ids will be concatenated with the default list.
 
 ## Note about Route Table and Security List
@@ -38,7 +38,6 @@ source = PATH_TO_MODULE
   compartment_id        = "ocixxxxxx.xxxxxx.xxxxx"
   name                  = "vcn-no-subnet"
   cidr_block            = "192.168.0.0/16"
-  allowed_ingress_ports = []
   private_subnets       = {}
   public_subnets        = {}
 ```
@@ -51,7 +50,6 @@ module "network" {
   compartment_id        = "ocixxxxxx.xxxxxx.xxxxx"
   name                  = "vcn"
   cidr_block            = "192.168.0.0/16"
-  allowed_ingress_ports = [80, 443]
 
   private_subnets = {
     "private-a" = {
@@ -80,17 +78,21 @@ module "network" {
   }
 
   default_security_list_rules = {
-    private_subnets = {
-      tcp_egress_ports_to_all = [80, 443]
-      udp_egress_ports_to_all = []
+    public_subnets = {
+      tcp_egress_ports_to_all    = [80, 443]
+      tcp_ingress_ports_from_all = [80, 443, 8080]
+      udp_egress_ports_to_all    = []
+      udp_ingress_ports_from_all = [53]
       enable_icpm_from_all      = true
       enable_icpm_to_all        = true
     }
-    public_subnets = {
-      tcp_egress_ports_to_all = [80, 443]
-      udp_egress_ports_to_all = []
-      enable_icpm_from_vcn      = true
-      enable_icpm_to_all        = true
+    private_subnets = {
+      tcp_egress_ports_to_all    = [80, 443]
+      tcp_ingress_ports_from_vcn = []
+      udp_egress_ports_to_all    = []
+      udp_ingress_ports_from_vcn = []
+      enable_icpm_from_vcn       = true
+      enable_icpm_to_all         = true
     }
   }
 }

--- a/modules/network/README.md
+++ b/modules/network/README.md
@@ -28,8 +28,10 @@ When the VCN is created, the following objects are created by default:
 * Route Table: the module will use default route table if not route table id is passed during creation of subnet. You can either configure the defaul route tables using `xxxxxx_route_table_rules` variables, or you can set different route table for each subnet you create using `route_table_id` key of the subnet you create.
 * Security List: the module will create defaul subnet list rules, and you can enhance that further by creating your own security list and pass them as IDs to the subnet. You can also use `default_security_list_rules` to specify list of egress ports to the internet for the public and private subnets.
 
-## Note about NAT gateway
-NAT gateway is configurable via `nat_configuration` variable. Traffic can be blocked. When `nat_configuration.block_traffic` is set to true, the route table rule `0.0.0.0/0` via NAT is removed from table.
+## Note about Gateways
+* NAT gateway is configurable via `nat_configuration` variable. Traffic can be blocked. When `nat_configuration.block_traffic` is set to true, the route table rule `0.0.0.0/0` via NAT is removed from table.
+
+* Internet gateway can be disabled via `enable_internet_gateway` variable.
 
 ## Limitations
 * The module does not support VCN Peering.
@@ -103,5 +105,7 @@ module "network" {
     public_ip_id = "oci.xxxxxxxx"
     block_traffic = true
   }
+
+  enable_internet_gateway = false
 }
 ```

--- a/modules/network/README.md
+++ b/modules/network/README.md
@@ -116,7 +116,8 @@ module "network" {
 
   service_gateway = {
     enable = true
-    service_id = ""
+    service_id = "ocid1.service.oc1.xxxxxxx"
+    route_rule_destination = "all-pox-services-in-oracle-services-network"
   }
 }
 ```

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -57,7 +57,7 @@ resource "oci_core_route_table" "private_route_table" {
   display_name   = "defaultPrivateRouteTable"
 
   dynamic "route_rules" {
-    for_each = var.nat_gateway_block_traffic == true ? [] : toset([1])
+    for_each = var.nat_configuration.block_traffic == true ? [] : toset([1])
     content {
       destination       = "0.0.0.0/0"
       destination_type  = "CIDR_BLOCK"

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -80,7 +80,7 @@ resource "oci_core_subnet" "public_subnet" {
   dhcp_options_id            = oci_core_default_dhcp_options.dhcp_options.id
   route_table_id             = lookup(each.value.optionals, "route_table_id", oci_core_default_route_table.public_route_table.id)
   dns_label                  = replace(replace(each.key, "-", ""), "_", "")
-  display_name               = "${each.key} subnet"
+  display_name               = "${each.value.name} subnet"
   security_list_ids          = concat([oci_core_default_security_list.public_subnet_security_list.id], each.value.security_list_ids)
 }
 

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -35,7 +35,7 @@ resource "oci_core_default_route_table" "public_route_table" {
   manage_default_resource_id = oci_core_vcn.vcn.default_route_table_id
   display_name               = "defaultRouteTable"
   dynamic "route_rules" {
-    for_each = var.enable_internet_gateway != true ? []:toset([1])
+    for_each = var.enable_internet_gateway != true ? [] : toset([1])
     content {
       destination       = "0.0.0.0/0"
       destination_type  = "CIDR_BLOCK"

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -54,7 +54,7 @@ resource "oci_core_service_gateway" "service_gateway" {
   vcn_id         = oci_core_vcn.vcn.id
   display_name   = "defaultServiceGateway"
   services {
-      service_id = var.service_gateway.service_id
+    service_id = var.service_gateway.service_id
   }
 }
 
@@ -97,7 +97,7 @@ resource "oci_core_route_table" "private_route_table" {
       network_entity_id = oci_core_nat_gateway.nat_gateway[0].id
     }
   }
-  
+
   dynamic "route_rules" {
     for_each = var.service_gateway.enable == true ? toset([0]) : []
     content {
@@ -106,7 +106,7 @@ resource "oci_core_route_table" "private_route_table" {
       network_entity_id = oci_core_service_gateway.service_gateway[0].id
     }
   }
-  
+
   dynamic "route_rules" {
     for_each = var.private_route_table_rules
     content {

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -11,6 +11,59 @@ variable "cidr_block" {
   description = "The CIDR block for the VCN"
 }
 
+# Gateways
+variable "nat_gateway" {
+  type = object({
+    enable        = bool
+    public_ip_id  = string
+    block_traffic = bool
+  })
+  default = {
+    enable        = true
+    block_traffic = false
+    public_ip_id  = ""
+  }
+
+  description = <<EOF
+    map of object to configure NAT
+      enable       : set to true to create a NAT Gateway and automatically add route rule in private route table
+      public_ip_id : ID of reserved public IP. Leave empty if you want oci to create random public IP
+      block_traffic: disable traffic on the NAT (but keep it in the route table!)
+  EOF
+}
+
+variable "internet_gateway" {
+  type = object({
+    enable = bool
+  })
+
+  default = {
+    enable = true
+  }
+  description = <<EOF
+    map of object to configure Internet Gateway
+      enable: set to true to create a Internet Gateway and automatically add route rule in public route table
+  EOF
+}
+
+variable "service_gateway" {
+  type = object({
+    enable     = bool
+    service_id = string
+  })
+
+  default = {
+    enable     = false
+    service_id = ""
+  }
+  description = <<EOF
+    map of object to configure Service Gateway
+      enable    : set to true to create a Service Gateway and automatically add route rule in private route table
+      service_id: The Services ID (check OCI Service Gateway docs)
+  EOF
+}
+
+# Subnets
 variable "private_subnets" {
   type = map(object({
     name              = string
@@ -51,6 +104,7 @@ variable "public_subnets" {
   EOL
 }
 
+# Routing
 variable "public_route_table_rules" {
   type = map(object({
     destination       = string
@@ -83,6 +137,7 @@ variable "private_route_table_rules" {
   EOL
 }
 
+# Security
 variable "default_security_list_rules" {
   type = object({
     public_subnets = object({
@@ -122,26 +177,4 @@ variable "default_security_list_rules" {
     }
   }
   description = "map of objects for allowed tcp and udp ingress/egress ports to the internet (0.0.0.0/0)"
-}
-
-variable "nat_configuration" {
-  type = object({
-    public_ip_id  = string
-    block_traffic = bool
-  })
-  default = {
-    block_traffic = false
-    public_ip_id  = ""
-  }
-
-  description = <<EOF
-    map of object to configure NAT
-      public_ip_id: ID of reserved public IP. Leave empty if you want oci to create random public IP
-      block_traffic: disable traffic on the NAT
-  EOF
-}
-
-variable "enable_internet_gateway" {
-  type    = bool
-  default = true
 }

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -48,14 +48,14 @@ variable "internet_gateway" {
 
 variable "service_gateway" {
   type = object({
-    enable     = bool
-    service_id = string
+    enable                 = bool
+    service_id             = string
     route_rule_destination = string
   })
 
   default = {
-    enable     = false
-    service_id = ""
+    enable                 = false
+    service_id             = ""
     route_rule_destination = ""
   }
   description = <<EOF

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -140,3 +140,8 @@ variable "nat_configuration" {
       block_traffic: disable traffic on the NAT
   EOF
 }
+
+variable "enable_internet_gateway" {
+  type    = bool
+  default = true
+}

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -11,13 +11,6 @@ variable "cidr_block" {
   description = "The CIDR block for the VCN"
 }
 
-#TODO: (Deprecation) this will move to default_security_list_rules in V2
-variable "allowed_ingress_ports" {
-  type        = list(number)
-  default     = []
-  description = "list of allowed ports that will allow inbound connection to machines in public subnet for default security list"
-}
-
 variable "private_subnets" {
   type = map(object({
     name              = string
@@ -97,36 +90,40 @@ variable "private_route_table_rules" {
 variable "default_security_list_rules" {
   type = object({
     public_subnets = object({
-      tcp_egress_ports_to_all = list(number)
-      udp_egress_ports_to_all = list(number)
-      enable_icpm_from_all    = bool
-      enable_icpm_to_all      = bool
-      #TODO V2: tcp_ingress_ports_from_all = list(number)
-      #TODO V2: udp_ingress_ports_from_all = list(number)
+      tcp_egress_ports_to_all    = list(number)
+      tcp_ingress_ports_from_all = list(number)
+      udp_egress_ports_to_all    = list(number)
+      udp_ingress_ports_from_all = list(number)
+      enable_icpm_from_all       = bool
+      enable_icpm_to_all         = bool
     })
     private_subnets = object({
-      tcp_egress_ports_to_all = list(number)
-      udp_egress_ports_to_all = list(number)
-      enable_icpm_from_vcn    = bool
-      enable_icpm_to_all      = bool
+      tcp_egress_ports_to_all    = list(number)
+      tcp_ingress_ports_from_vcn = list(number)
+      udp_egress_ports_to_all    = list(number)
+      udp_ingress_ports_from_vcn = list(number)
+      enable_icpm_from_vcn       = bool
+      enable_icpm_to_all         = bool
     })
   })
 
   default = {
     public_subnets = {
-      tcp_egress_ports_to_all = []
-      udp_egress_ports_to_all = []
-      enable_icpm_from_all    = false
-      enable_icpm_to_all      = false
-      #TODO V2: tcp_ingress_ports_from_all = []
-      #TODO V2: udp_ingress_ports_from_all = []
+      tcp_egress_ports_to_all    = []
+      tcp_ingress_ports_from_all = []
+      udp_egress_ports_to_all    = []
+      udp_ingress_ports_from_all = []
+      enable_icpm_from_all       = false
+      enable_icpm_to_all         = false
     }
     private_subnets = {
-      tcp_egress_ports_to_all = []
-      udp_egress_ports_to_all = []
-      enable_icpm_from_vcn    = false
-      enable_icpm_to_all      = false
+      tcp_egress_ports_to_all    = []
+      tcp_ingress_ports_from_vcn = []
+      udp_egress_ports_to_all    = []
+      udp_ingress_ports_from_vcn = []
+      enable_icpm_from_vcn       = false
+      enable_icpm_to_all         = false
     }
   }
-  description = "map of objects for allowed tcp and udp egress ports to the internet (0.0.0.0/0)"
+  description = "map of objects for allowed tcp and udp ingress/egress ports to the internet (0.0.0.0/0)"
 }

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -20,6 +20,7 @@ variable "allowed_ingress_ports" {
 
 variable "private_subnets" {
   type = map(object({
+    name              = string
     cidr_block        = string
     security_list_ids = list(string)
     optionals         = any # map(any)
@@ -28,7 +29,8 @@ variable "private_subnets" {
   }))
 
   description = <<EOL
-  map of subnet object configurations. Key is used as subnet name in the FQDN
+  map of subnet object configurations. Key is used as subnet name in the FQDN (as dns_label)
+    name             : the display name of the subnet (node dns_label can't be updated)
     cidr_block       : the cidr block for the subnet
     security_list_ids: list of security ids to be attached to the subnet
     optionals        : map of optional values
@@ -38,6 +40,7 @@ variable "private_subnets" {
 
 variable "public_subnets" {
   type = map(object({
+    name              = string
     cidr_block        = string
     security_list_ids = list(string)
     optionals         = map(any)
@@ -48,7 +51,8 @@ variable "public_subnets" {
   }))
 
   description = <<EOL
-  map of subnet object configurations. Key is used as subnet name in the FQDN
+  map of subnet object configurations. Key is used as subnet name in the FQDN (as dns_label)
+    name             : the display name of the subnet (node dns_label can't be updated)
     cidr_block       : the cidr block for the subnet
     security_list_ids: list of security ids to be attached to the subnet
     optionals        : map of optional values

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -39,8 +39,6 @@ variable "public_subnets" {
     optionals         = map(any)
     # The followings are the keys for the optionals with defaults in brackets
     # route_table_id = string # id of custom route table
-    # allow_tcp_egress_to_ports = list(string) # egress tcp ports to 0.0.0.0/0
-    # allow_udp_egress_to_ports = list(string) # egress udp ports to 0.0.0.0/0
   }))
 
   description = <<EOL
@@ -50,8 +48,6 @@ variable "public_subnets" {
     security_list_ids: list of security ids to be attached to the subnet
     optionals        : map of optional values
       route_table_id: route table id to be used instead of defaul one
-      allow_tcp_egress_to_ports: egress tcp ports to 0.0.0.0/0 to be added to default security list
-      allow_udp_egress_to_ports: egress udp ports to 0.0.0.0/0 to be added to default security list
   EOL
 }
 

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -127,3 +127,20 @@ variable "default_security_list_rules" {
   }
   description = "map of objects for allowed tcp and udp ingress/egress ports to the internet (0.0.0.0/0)"
 }
+
+variable "nat_configuration" {
+  type = object({
+    public_ip_id  = string
+    block_traffic = bool
+  })
+  default = {
+    block_traffic = false
+    public_ip_id  = ""
+  }
+
+  description = <<EOF
+    map of object to configure NAT
+      public_ip_id: ID of reserved public IP. Leave empty if you want oci to create random public IP
+      block_traffic: disable traffic on the NAT
+  EOF
+}

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -50,11 +50,13 @@ variable "service_gateway" {
   type = object({
     enable     = bool
     service_id = string
+    route_rule_destination = string
   })
 
   default = {
     enable     = false
     service_id = ""
+    route_rule_destination = ""
   }
   description = <<EOF
     map of object to configure Service Gateway

--- a/modules/object-storage/README.md
+++ b/modules/object-storage/README.md
@@ -14,6 +14,20 @@ module "buckets" {
       compartment_id = "ocixxxxxx.xxxxxx.xxxxx"
       storage_tier   = "Standard"
       is_public      = true
+      lifecycle_rules = {
+        "test-1" = {
+          name               = "test"
+          action             = "DELETE"
+          enabled            = true
+          target             = "objects"
+          time               = 1
+          time_unit          = "DAYS"
+          exclusion_patterns = []
+          inclusion_patterns = []
+          inclusion_prefixes = []
+
+        }
+      }
       optionals      = {
         object_events_enabled = false 
         versioning_enabled = true
@@ -25,6 +39,20 @@ module "buckets" {
       compartment_id = "ocixxxxxx.xxxxxx.xxxxx"
       storage_tier   = "Standard"
       is_public      = true
+      lifecycle_rules = {
+        "test-2" = {
+          name               = "test2"
+          action             = "ARCHIVE"
+          enabled            = true
+          target             = "objects"
+          time               = 1
+          time_unit          = "DAYS"
+          exclusion_patterns = []
+          inclusion_patterns = []
+          inclusion_prefixes = []
+
+        }
+      }
       optionals      = {}
     }
   }

--- a/modules/object-storage/main.tf
+++ b/modules/object-storage/main.tf
@@ -1,15 +1,36 @@
 data "oci_objectstorage_namespace" "namespace" {}
 
-
 resource "oci_objectstorage_bucket" "bucket" {
   for_each = var.buckets
 
-  namespace = data.oci_objectstorage_namespace.namespace.namespace
-
+  namespace             = data.oci_objectstorage_namespace.namespace.namespace
   compartment_id        = each.value.compartment_id
   name                  = each.value.name
   access_type           = each.value.is_public == true ? "ObjectReadWithoutList" : "NoPublicAccess"
   storage_tier          = each.value.storage_tier
   object_events_enabled = lookup(each.value.optionals, "object_events_enabled", false)
   versioning            = lookup(each.value.optionals, "versioning_enabled", false) ? "Enabled" : "Disabled"
+}
+
+resource "oci_objectstorage_object_lifecycle_policy" "lifecycle_policy" {
+  for_each  = var.buckets
+  bucket    = oci_objectstorage_bucket.bucket.key[name] //to make dependency with bucket resoruce 
+  namespace = data.oci_objectstorage_namespace.namespace.namespace
+
+  dynamic "rules" {
+    for_each = each.value.lifecycle_rules
+    content {
+      action     = rules.value.action
+      is_enabled = rules.value.enabled
+      name       = rules.value.name
+      object_name_filter {
+        exclusion_patterns = rules.value.exclusion_patterns
+        inclusion_patterns = rules.value.inclusion_patterns
+        inclusion_prefixes = rules.value.inclusion_prefixes
+      }
+      target      = rules.value.target
+      time_amount = rules.value.time
+      time_unit   = rules.value.time_unit
+    }
+  }
 }

--- a/modules/object-storage/main.tf
+++ b/modules/object-storage/main.tf
@@ -18,7 +18,7 @@ resource "oci_objectstorage_object_lifecycle_policy" "lifecycle_policy" {
   namespace = data.oci_objectstorage_namespace.namespace.namespace
 
   dynamic "rules" {
-    for_each = each.value.lifecycle_rules
+    for_each = { for k, v in each.value.lifecycle_rules : k => v if v.target != "multipart-uploads" }
     content {
       action     = rules.value.action
       is_enabled = rules.value.enabled
@@ -28,6 +28,18 @@ resource "oci_objectstorage_object_lifecycle_policy" "lifecycle_policy" {
         inclusion_patterns = rules.value.inclusion_patterns
         inclusion_prefixes = rules.value.inclusion_prefixes
       }
+      target      = rules.value.target
+      time_amount = rules.value.time
+      time_unit   = rules.value.time_unit
+    }
+  }
+
+  dynamic "rules" {
+    for_each = { for k, v in each.value.lifecycle_rules : k => v if v.target == "multipart-uploads" }
+    content {
+      action      = rules.value.action
+      is_enabled  = rules.value.enabled
+      name        = rules.value.name
       target      = rules.value.target
       time_amount = rules.value.time
       time_unit   = rules.value.time_unit

--- a/modules/object-storage/main.tf
+++ b/modules/object-storage/main.tf
@@ -23,14 +23,10 @@ resource "oci_objectstorage_object_lifecycle_policy" "lifecycle_policy" {
       action     = rules.value.action
       is_enabled = rules.value.enabled
       name       = rules.value.name
-
-      dynamic "object_name_filter" {
-        for_each = rules.value.target == "multipart-uploads" ? [true] : []
-        content {
-          exclusion_patterns = rules.value.exclusion_patterns
-          inclusion_patterns = rules.value.inclusion_patterns
-          inclusion_prefixes = rules.value.inclusion_prefixes
-        }
+      object_name_filter {
+        exclusion_patterns = rules.value.exclusion_patterns
+        inclusion_patterns = rules.value.inclusion_patterns
+        inclusion_prefixes = rules.value.inclusion_prefixes
       }
       target      = rules.value.target
       time_amount = rules.value.time

--- a/modules/object-storage/main.tf
+++ b/modules/object-storage/main.tf
@@ -23,10 +23,14 @@ resource "oci_objectstorage_object_lifecycle_policy" "lifecycle_policy" {
       action     = rules.value.action
       is_enabled = rules.value.enabled
       name       = rules.value.name
-      object_name_filter {
-        exclusion_patterns = rules.value.exclusion_patterns
-        inclusion_patterns = rules.value.inclusion_patterns
-        inclusion_prefixes = rules.value.inclusion_prefixes
+
+      dynamic "object_name_filter" {
+        for_each = rules.value.target == "multipart-uploads" ? [true] : []
+        content {
+          exclusion_patterns = rules.value.exclusion_patterns
+          inclusion_patterns = rules.value.inclusion_patterns
+          inclusion_prefixes = rules.value.inclusion_prefixes
+        }
       }
       target      = rules.value.target
       time_amount = rules.value.time

--- a/modules/object-storage/main.tf
+++ b/modules/object-storage/main.tf
@@ -14,7 +14,7 @@ resource "oci_objectstorage_bucket" "bucket" {
 
 resource "oci_objectstorage_object_lifecycle_policy" "lifecycle_policy" {
   for_each  = var.buckets
-  bucket    = oci_objectstorage_bucket.bucket.key[name] //to make dependency with bucket resoruce 
+  bucket    = oci_objectstorage_bucket.bucket[each.key].name
   namespace = data.oci_objectstorage_namespace.namespace.namespace
 
   dynamic "rules" {

--- a/modules/object-storage/variables.tf
+++ b/modules/object-storage/variables.tf
@@ -15,7 +15,7 @@ variable "buckets" {
       time               = string
       time_unit          = string
     }))
-    optionals = any # map(any)
+    optionals = map(any)
     # The followings are the keys for the optionals with defaults in brackets
     # object_events_enabled = bool - false
     # versioning_enabled    = bool - false

--- a/modules/object-storage/variables.tf
+++ b/modules/object-storage/variables.tf
@@ -1,10 +1,21 @@
 variable "buckets" {
   type = map(object({
-    name           = string
     compartment_id = string
+    name           = string
     storage_tier   = string
     is_public      = bool
-    optionals      = any # map(any)
+    lifecycle_rules = map(object({
+      name               = string
+      action             = string
+      enabled            = string
+      exclusion_patterns = list(string)
+      inclusion_patterns = list(string)
+      inclusion_prefixes = list(string)
+      target             = string
+      time               = string
+      time_unit          = string
+    }))
+    optionals = any # map(any)
     # The followings are the keys for the optionals with defaults in brackets
     # object_events_enabled = bool - false
     # versioning_enabled    = bool - false

--- a/modules/public-ip/README.md
+++ b/modules/public-ip/README.md
@@ -2,16 +2,91 @@
 
 Create and reserve public IPs in a given compartment. This module is self documented, check `variables.tf`
 
+## `untracked_ips` vs `tracked_ips`
 
+Use `untracked_ips` if you plan to manage private IP assignment manually (or not via Terraform). Terraform will ignore any changes made to `private_ip_id` attribute of the public kIPey. A good use case if you want to assign public IP to Network Load Balancer.
+
+Use `tracked_ips` when you will assign the public IP to a VNIC via a known private IP. Note that you can still create `tracked_ips` without private IP assignment, and assign private IP at later time.
+
+## Moving public IP from `untracked_ips` to `tracked_ips` and vice versa
+
+You can migrate `tracked_ips` to `untracked_ips` and vice versa using `terraform state mv`
+### Migrating `untracked_ips` to `tracked_ips`
+Assuming you have the following input
+```
+module "my_public_ips" {
+  source         = PATH_TO_MODULE
+  compartment_id = "ocixxxxxx.xxxxxx.xxxxx"
+  untracked_ips  = toset(["machine-1", "prod-lb-ip"])
+  tracked_ips    = {}
+}
+```
+and you want to start tracking `machine-1` public IP.
+  1. Remove the `machine-1` from `untracked_ips` variable input.
+  ```
+  untracked_ips  = toset(["prod-lb-ip"])
+  ```
+  2. Create new key for `tracked_ips` with the same name `machine-1`
+  ```
+  tracked_ips    = { 
+    "machine-1" = {
+      private_ip_id = ""
+      name          = "machine-1"
+    }
+  }
+  ```
+  3. Run the following (assuming you named you module `my_public_ips`):
+
+```
+terraform state mv module.my_public_ips.oci_core_public_ip.ip\[\"machine-1\"\] mv module.my_public_ips.oci_core_public_ip.tracked_ip\[\"machine-1\"\]
+```
+
+### Migrating `untracked_ips` to `tracked_ips`
+Assuming you have the following input
+```
+module "my_public_ips" {
+  source         = PATH_TO_MODULE
+  compartment_id = "ocixxxxxx.xxxxxx.xxxxx"
+  untracked_ips  = toset(["prod-lb-ip"])
+  tracked_ips    = { 
+    "machine-1" = {
+      private_ip_id = ""
+      name          = "machine-1"
+    }
+  }
+}
+```
+and you want to STOP tracking `machine-1` public IP.
+  1. Remove the `machine-1` from `tracked_ips` variable input.
+  ```
+  untracked_ips  = {}
+  ```
+  2. Create new item for `untracked_ips` with the same name `machine-1`
+  ```
+  untracked_ips  = toset(["prod-lb-ip", "machine-1"])
+  ```
+  3. Run the following (assuming you named you module `my_public_ips`):
+
+```
+terraform state mv module.my_public_ips.oci_core_public_ip.tracked_ip\[\"machine-1\"\] mv module.my_public_ips.oci_core_public_ip.ip\[\"machine-1\"\]
+```
 # Example
-The following creates two public IPs with the names:
-* machine-1
-* prod-lb-ip
-
 ```h
 module "public_ips" {
   source         = PATH_TO_MODULE
   compartment_id = "ocixxxxxx.xxxxxx.xxxxx"
-  ips            = toset(["machine-1", "prod-lb-ip"])
+  untracked_ips  = toset(["machine-1", "prod-lb-ip"])
+  tracked_ips    = {
+    "public_ip_a" = {
+      # will NOT assign the public IP to any private IP yet
+      private_ip_id = ""
+      name          = "public A"
+    }
+    "public_ip_v" = {
+      # will assign the public IP to the private IP of private_ip_id
+      private_ip_id = "ocixxxxxx.xxxxxx.xxxxx"
+      name          = "public B"
+    }
+  }
 }
 ```

--- a/modules/public-ip/main.tf
+++ b/modules/public-ip/main.tf
@@ -1,12 +1,22 @@
 resource "oci_core_public_ip" "ip" {
-  for_each = toset(var.ips)
+  for_each = toset(var.untracked_ips)
 
   compartment_id = var.compartment_id
   lifetime       = "RESERVED" # if it gets disconnected from insistence it will destroy itself
-  display_name   = "${each.key}-public-ip"
+  display_name   = each.key
 
   lifecycle {
     # it is going to be assigned after creation so lets ignore its change
     ignore_changes = [private_ip_id, defined_tags]
   }
+}
+
+
+resource "oci_core_public_ip" "tracked_ip" {
+  for_each = var.tracked_ips
+
+  compartment_id = var.compartment_id
+  lifetime       = "RESERVED"
+  display_name   = each.value.name
+  private_ip_id  = each.value.private_ip_id
 }

--- a/modules/public-ip/output.tf
+++ b/modules/public-ip/output.tf
@@ -1,5 +1,19 @@
-output "ips" {
+output "untracked_ips" {
   value = {
-    for key, value in oci_core_public_ip.ip : key => value
+    for key, value in oci_core_public_ip.ip : key => {
+      id            = value.id
+      ip            = value.ip_address
+      private_ip_id = value.private_ip_id
+    }
+  }
+}
+
+output "tracked_ips" {
+  value = {
+    for key, value in oci_core_public_ip.tracked_ip : key => {
+      id            = value.id
+      ip            = value.ip_address
+      private_ip_id = value.private_ip_id
+    }
   }
 }

--- a/modules/public-ip/variables.tf
+++ b/modules/public-ip/variables.tf
@@ -16,7 +16,7 @@ variable "tracked_ips" {
     private_ip_id = string
     name          = string
   }))
-  default = {}
+  default     = {}
   description = <<EOF
     Map of private IP id to assign to the created public IP. Terraform manages private IP assignments and TRACKS changes (check README.md)
   EOF

--- a/modules/public-ip/variables.tf
+++ b/modules/public-ip/variables.tf
@@ -3,7 +3,21 @@ variable "compartment_id" {
   description = "oci of the compartment"
 }
 
-variable "ips" {
+variable "untracked_ips" {
   type        = list(string)
-  description = "This is a list of IPs NAMES (public IPs are created randomly by oci)"
+  default     = []
+  description = <<EOF
+    This is a list of IPs NAMES that will NOT be assigned to private IPs by Terraform. Terraform IGNORES changes made to private IP assignment (check README.md)
+  EOF
+}
+
+variable "tracked_ips" {
+  type = map(object({
+    private_ip_id = string
+    name          = string
+  }))
+  default = {}
+  description = <<EOF
+    Map of private IP id to assign to the created public IP. Terraform manages private IP assignments and TRACKS changes (check README.md)
+  EOF
 }

--- a/modules/vault/locals.tf
+++ b/modules/vault/locals.tf
@@ -1,0 +1,46 @@
+locals {
+ 
+  flattened_keys = flatten([
+    for vault_ref, vault in var.vaults: [
+      for key_ref, key in vault.keys : merge(key, { vault_ref = vault_ref, key_ref = key_ref })
+    ]
+  ])
+  
+  flattened_keys_rotations = flatten([
+    for vault_ref, vault in var.vaults: [
+      for key_ref, key in vault.keys : [
+        for version in key.versions: {version = version, vault_ref = vault_ref, key_ref = key_ref }
+      ]
+    ]
+  ])
+  
+  flattened_keys_for_file_restored_vault = flatten([
+    for vault_ref, vault in var.file_restored_vaults: [
+      for key_ref, key in vault.keys : merge(key, { vault_ref = vault_ref, key_ref = key_ref })
+    ]
+  ])
+
+  flattened_keys_rotations_for_file_restored_vault = flatten([
+    for vault_ref, vault in var.file_restored_vaults: [
+      for key_ref, key in vault.keys : [
+        for version in key.versions: {version = version, vault_ref = vault_ref, key_ref = key_ref }
+      ]
+    ]
+  ])
+  
+  flattened_keys_for_object_restored_vault = flatten([
+    for vault_ref, vault in var.object_store_restored_vaults: [
+      for key_ref, key in vault.keys : merge(key, { vault_ref = vault_ref, key_ref = key_ref })
+    ]
+  ])
+
+  flattened_keys_rotations_for_object_restored_vault = flatten([
+    for vault_ref, vault in var.object_store_restored_vaults: [
+      for key_ref, key in vault.keys : [
+        for version in key.versions: {version = version, vault_ref = vault_ref, key_ref = key_ref }
+      ]
+    ]
+  ])
+
+
+}

--- a/modules/vault/locals.tf
+++ b/modules/vault/locals.tf
@@ -1,43 +1,43 @@
 locals {
- 
+
   flattened_keys = flatten([
-    for vault_ref, vault in var.vaults: [
+    for vault_ref, vault in var.vaults : [
       for key_ref, key in vault.keys : merge(key, { vault_ref = vault_ref, key_ref = key_ref })
     ]
   ])
-  
+
   flattened_keys_rotations = flatten([
-    for vault_ref, vault in var.vaults: [
+    for vault_ref, vault in var.vaults : [
       for key_ref, key in vault.keys : [
-        for version in key.versions: {version = version, vault_ref = vault_ref, key_ref = key_ref }
+        for version in key.versions : { version = version, vault_ref = vault_ref, key_ref = key_ref }
       ]
     ]
   ])
-  
+
   flattened_keys_for_file_restored_vault = flatten([
-    for vault_ref, vault in var.file_restored_vaults: [
+    for vault_ref, vault in var.file_restored_vaults : [
       for key_ref, key in vault.keys : merge(key, { vault_ref = vault_ref, key_ref = key_ref })
     ]
   ])
 
   flattened_keys_rotations_for_file_restored_vault = flatten([
-    for vault_ref, vault in var.file_restored_vaults: [
+    for vault_ref, vault in var.file_restored_vaults : [
       for key_ref, key in vault.keys : [
-        for version in key.versions: {version = version, vault_ref = vault_ref, key_ref = key_ref }
+        for version in key.versions : { version = version, vault_ref = vault_ref, key_ref = key_ref }
       ]
     ]
   ])
-  
+
   flattened_keys_for_object_restored_vault = flatten([
-    for vault_ref, vault in var.object_store_restored_vaults: [
+    for vault_ref, vault in var.object_store_restored_vaults : [
       for key_ref, key in vault.keys : merge(key, { vault_ref = vault_ref, key_ref = key_ref })
     ]
   ])
 
   flattened_keys_rotations_for_object_restored_vault = flatten([
-    for vault_ref, vault in var.object_store_restored_vaults: [
+    for vault_ref, vault in var.object_store_restored_vaults : [
       for key_ref, key in vault.keys : [
-        for version in key.versions: {version = version, vault_ref = vault_ref, key_ref = key_ref }
+        for version in key.versions : { version = version, vault_ref = vault_ref, key_ref = key_ref }
       ]
     ]
   ])

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -2,31 +2,31 @@
 
 resource "oci_kms_vault" "vault" {
   for_each = var.vaults
-  
+
   compartment_id = each.value.compartment_id
-  display_name = each.value.name
-  vault_type = each.value.type
+  display_name   = each.value.name
+  vault_type     = each.value.type
 }
 
 resource "oci_kms_key" "key" {
-  for_each = { for item in local.flattened_keys: "${item.vault_ref}:${item.key_ref}" => item }
-  
+  for_each = { for item in local.flattened_keys : "${item.vault_ref}:${item.key_ref}" => item }
+
   compartment_id = each.value.compartment_id
-  display_name = each.value.name
-  desired_state = each.value.enabled ? "ENABLED" : "DISABLED"
+  display_name   = each.value.name
+  desired_state  = each.value.enabled ? "ENABLED" : "DISABLED"
   key_shape {
-      algorithm = each.value.algorithm
-      length = each.value.length
+    algorithm = each.value.algorithm
+    length    = each.value.length
   }
 
   management_endpoint = oci_kms_vault.vault[each.value.vault_ref].management_endpoint
-  protection_mode = each.value.mode
+  protection_mode     = each.value.mode
 }
 
 resource "oci_kms_key_version" "key_version" {
-  for_each = {for item in local.flattened_keys_rotations: "${item.vault_ref}:${item.key_ref}:${item.version}" => item}
+  for_each = { for item in local.flattened_keys_rotations : "${item.vault_ref}:${item.key_ref}:${item.version}" => item }
 
-  key_id = oci_kms_key.key["${each.value.vault_ref}:${each.value.key_ref}"].id
+  key_id              = oci_kms_key.key["${each.value.vault_ref}:${each.value.key_ref}"].id
   management_endpoint = oci_kms_vault.vault[each.value.vault_ref].management_endpoint
 }
 
@@ -36,34 +36,34 @@ resource "oci_kms_vault" "file_restored_vault" {
   for_each = var.file_restored_vaults
 
   compartment_id = each.value.compartment_id
-  display_name = each.value.name
-  vault_type = each.value.type
+  display_name   = each.value.name
+  vault_type     = each.value.type
   restore_from_file {
-    content_length = each.value.file.length
-    content_md5 = each.value.file.md5
+    content_length                  = each.value.file.length
+    content_md5                     = each.value.file.md5
     restore_vault_from_file_details = each.value.file.content
   }
 }
 
 resource "oci_kms_key" "key_for_file_restored_vault" {
-  for_each = { for item in local.flattened_keys_for_file_restored_vault: "${item.vault_ref}:${item.key_ref}" => item }
-  
+  for_each = { for item in local.flattened_keys_for_file_restored_vault : "${item.vault_ref}:${item.key_ref}" => item }
+
   compartment_id = each.value.compartment_id
-  display_name = each.value.name
-  desired_state = each.value.enabled ? "ENABLED" : "DISABLED"
+  display_name   = each.value.name
+  desired_state  = each.value.enabled ? "ENABLED" : "DISABLED"
   key_shape {
-      algorithm = each.value.algorithm
-      length = each.value.length
+    algorithm = each.value.algorithm
+    length    = each.value.length
   }
 
   management_endpoint = oci_kms_vault.vault[each.value.vault_ref].management_endpoint
-  protection_mode = each.value.mode
+  protection_mode     = each.value.mode
 }
 
 resource "oci_kms_key_version" "key_version_for_file_restored_vault" {
-  for_each = {for item in local.flattened_keys_rotations_for_file_restored_vault: "${item.vault_ref}:${item.key_ref}:${item.version}" => item}
+  for_each = { for item in local.flattened_keys_rotations_for_file_restored_vault : "${item.vault_ref}:${item.key_ref}:${item.version}" => item }
 
-  key_id = oci_kms_key.key["${each.value.vault_ref}:${each.value.key_ref}"].id
+  key_id              = oci_kms_key.key["${each.value.vault_ref}:${each.value.key_ref}"].id
   management_endpoint = oci_kms_vault.vault[each.value.vault_ref].management_endpoint
 }
 
@@ -72,35 +72,35 @@ resource "oci_kms_vault" "object_store_restored_vault" {
   for_each = var.object_store_restored_vaults
 
   compartment_id = each.value.compartment_id
-  display_name = each.value.name
-  vault_type = each.value.type
+  display_name   = each.value.name
+  vault_type     = each.value.type
   restore_from_object_store {
-    bucket = each.value.oci_object_store.bucket
+    bucket      = each.value.oci_object_store.bucket
     destination = each.value.oci_object_store.destination
-    namespace = each.value.oci_object_store.namespace
-    object = each.value.oci_object_store.object
-    uri = each.value.oci_object_store.uri
+    namespace   = each.value.oci_object_store.namespace
+    object      = each.value.oci_object_store.object
+    uri         = each.value.oci_object_store.uri
   }
 }
 
 resource "oci_kms_key" "key_for_object_restored_vault" {
-  for_each = { for item in local.flattened_keys_for_object_restored_vault: "${item.vault_ref}:${item.key_ref}" => item }
-  
+  for_each = { for item in local.flattened_keys_for_object_restored_vault : "${item.vault_ref}:${item.key_ref}" => item }
+
   compartment_id = each.value.compartment_id
-  display_name = each.value.name
-  desired_state = each.value.enabled ? "ENABLED" : "DISABLED"
+  display_name   = each.value.name
+  desired_state  = each.value.enabled ? "ENABLED" : "DISABLED"
   key_shape {
-      algorithm = each.value.algorithm
-      length = each.value.length
+    algorithm = each.value.algorithm
+    length    = each.value.length
   }
 
   management_endpoint = oci_kms_vault.vault[each.value.vault_ref].management_endpoint
-  protection_mode = each.value.mode
+  protection_mode     = each.value.mode
 }
 
 resource "oci_kms_key_version" "key_version_for_object_restored_vault" {
-  for_each = {for item in local.flattened_keys_rotations_for_object_restored_vault: "${item.vault_ref}:${item.key_ref}:${item.version}" => item}
+  for_each = { for item in local.flattened_keys_rotations_for_object_restored_vault : "${item.vault_ref}:${item.key_ref}:${item.version}" => item }
 
-  key_id = oci_kms_key.key["${each.value.vault_ref}:${each.value.key_ref}"].id
+  key_id              = oci_kms_key.key["${each.value.vault_ref}:${each.value.key_ref}"].id
   management_endpoint = oci_kms_vault.vault[each.value.vault_ref].management_endpoint
 }

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -8,50 +8,6 @@ resource "oci_kms_vault" "vault" {
   vault_type = each.value.type
 }
 
-resource "oci_kms_vault" "file_restored_vault" {
-  for_each = var.file_restored_vaults
-
-  compartment_id = each.value.compartment_id
-  display_name = each.value.name
-  vault_type = each.value.type
-  restore_from_file {
-    content_length = each.value.file.length
-    content_md5 = each.value.file.md5
-    restore_vault_from_file_details = each.value.file.content
-  }
-}
-
-resource "oci_kms_vault" "object_store_restored_vault" {
-  for_each = var.object_store_restored_vaults
-
-  compartment_id = each.value.compartment_id
-  display_name = each.value.name
-  vault_type = each.value.type
-  restore_from_object_store {
-    bucket = each.value.oci_object_store.bucket
-    destination = each.value.oci_object_store.destination
-    namespace = each.value.oci_object_store.namespace
-    object = each.value.oci_object_store.object
-    uri = each.value.oci_object_store.uri
-  }
-}
-
-locals {
-  flattened_keys = flatten([
-    for vault_ref, vault in var.vaults: [
-      for key_ref, key in vault.keys : merge(key, { vault_ref = vault_ref, key_ref = key_ref })
-    ]
-  ])
-
-  flattened_keys_rotations = flatten([
-    for vault_ref, vault in var.vaults: [
-      for key_ref, key in vault.keys : [
-        for version in key.versions: {version = version, vault_ref = vault_ref, key_ref = key_ref }
-      ]
-    ]
-  ])
-}
-
 resource "oci_kms_key" "key" {
   for_each = { for item in local.flattened_keys: "${item.vault_ref}:${item.key_ref}" => item }
   
@@ -69,6 +25,81 @@ resource "oci_kms_key" "key" {
 
 resource "oci_kms_key_version" "key_version" {
   for_each = {for item in local.flattened_keys_rotations: "${item.vault_ref}:${item.key_ref}:${item.version}" => item}
+
+  key_id = oci_kms_key.key["${each.value.vault_ref}:${each.value.key_ref}"].id
+  management_endpoint = oci_kms_vault.vault[each.value.vault_ref].management_endpoint
+}
+
+
+// File Restored
+resource "oci_kms_vault" "file_restored_vault" {
+  for_each = var.file_restored_vaults
+
+  compartment_id = each.value.compartment_id
+  display_name = each.value.name
+  vault_type = each.value.type
+  restore_from_file {
+    content_length = each.value.file.length
+    content_md5 = each.value.file.md5
+    restore_vault_from_file_details = each.value.file.content
+  }
+}
+
+resource "oci_kms_key" "key_for_file_restored_vault" {
+  for_each = { for item in local.flattened_keys_for_file_restored_vault: "${item.vault_ref}:${item.key_ref}" => item }
+  
+  compartment_id = each.value.compartment_id
+  display_name = each.value.name
+  desired_state = each.value.enabled ? "ENABLED" : "DISABLED"
+  key_shape {
+      algorithm = each.value.algorithm
+      length = each.value.length
+  }
+
+  management_endpoint = oci_kms_vault.vault[each.value.vault_ref].management_endpoint
+  protection_mode = each.value.mode
+}
+
+resource "oci_kms_key_version" "key_version_for_file_restored_vault" {
+  for_each = {for item in local.flattened_keys_rotations_for_file_restored_vault: "${item.vault_ref}:${item.key_ref}:${item.version}" => item}
+
+  key_id = oci_kms_key.key["${each.value.vault_ref}:${each.value.key_ref}"].id
+  management_endpoint = oci_kms_vault.vault[each.value.vault_ref].management_endpoint
+}
+
+// Object Store Restored
+resource "oci_kms_vault" "object_store_restored_vault" {
+  for_each = var.object_store_restored_vaults
+
+  compartment_id = each.value.compartment_id
+  display_name = each.value.name
+  vault_type = each.value.type
+  restore_from_object_store {
+    bucket = each.value.oci_object_store.bucket
+    destination = each.value.oci_object_store.destination
+    namespace = each.value.oci_object_store.namespace
+    object = each.value.oci_object_store.object
+    uri = each.value.oci_object_store.uri
+  }
+}
+
+resource "oci_kms_key" "key_for_object_restored_vault" {
+  for_each = { for item in local.flattened_keys_for_object_restored_vault: "${item.vault_ref}:${item.key_ref}" => item }
+  
+  compartment_id = each.value.compartment_id
+  display_name = each.value.name
+  desired_state = each.value.enabled ? "ENABLED" : "DISABLED"
+  key_shape {
+      algorithm = each.value.algorithm
+      length = each.value.length
+  }
+
+  management_endpoint = oci_kms_vault.vault[each.value.vault_ref].management_endpoint
+  protection_mode = each.value.mode
+}
+
+resource "oci_kms_key_version" "key_version_for_object_restored_vault" {
+  for_each = {for item in local.flattened_keys_rotations_for_object_restored_vault: "${item.vault_ref}:${item.key_ref}:${item.version}" => item}
 
   key_id = oci_kms_key.key["${each.value.vault_ref}:${each.value.key_ref}"].id
   management_endpoint = oci_kms_vault.vault[each.value.vault_ref].management_endpoint

--- a/modules/vault/main.tf
+++ b/modules/vault/main.tf
@@ -1,0 +1,60 @@
+#TODO v3 support replication in regions
+
+resource "oci_kms_vault" "vault" {
+    #Required
+    compartment_id = var.compartment_id
+    display_name = var.vault_display_name
+    vault_type = var.vault_vault_type
+
+    restore_from_file {
+      content_length = ""
+      content_md5 = ""
+      restore_vault_from_file_details = ""
+    }
+
+    restore_from_object_store {
+      bucket = ""
+      destination = ""
+      namespace = ""
+      object = ""
+      uri = ""
+    }
+}
+
+resource "oci_kms_key" "key" {
+    #Required
+    compartment_id = var.compartment_id
+    display_name = var.key_display_name
+    desired_state = ""
+    key_shape {
+        algorithm = var.key_key_shape_algorithm
+        length = var.key_key_shape_length
+        curve_id = oci_kms_curve.test_curve.id
+    }
+    management_endpoint = var.key_management_endpoint
+
+    protection_mode = "${var.key_protection_mode}"
+
+    restore_from_file {
+      content_length = ""
+      content_md5 = ""
+      restore_vault_from_file_details = ""
+    }
+
+    restore_from_object_store {
+      bucket = ""
+      destination = ""
+      namespace = ""
+      object = ""
+      uri = ""
+    }
+    restore_trigger  = ""
+    time_of_deletion = ""
+}
+
+resource "oci_kms_key_version" "key_version" {
+    #Required
+    key_id = oci_kms_key.test_key.id
+    management_endpoint = var.key_version_management_endpoint
+}
+w

--- a/modules/vault/output.tf
+++ b/modules/vault/output.tf
@@ -1,59 +1,59 @@
 output "vaults" {
   value = {
-    created_vaults = { for vault_ref, vault in var.vaults: 
+    created_vaults = { for vault_ref, vault in var.vaults :
       vault_ref => {
-        id = oci_kms_vault.vault[vault_ref].id
-        crypto_endpoint = oci_kms_vault.vault[vault_ref].crypto_endpoint
-        management_endpoint =  oci_kms_vault.vault[vault_ref].management_endpoint
-        keys = {for key_ref, key in vault.keys: key_ref => {
-          id = oci_kms_key.key["${vault_ref}:${key_ref}"].id
+        id                  = oci_kms_vault.vault[vault_ref].id
+        crypto_endpoint     = oci_kms_vault.vault[vault_ref].crypto_endpoint
+        management_endpoint = oci_kms_vault.vault[vault_ref].management_endpoint
+        keys = { for key_ref, key in vault.keys : key_ref => {
+          id       = oci_kms_key.key["${vault_ref}:${key_ref}"].id
           vault_id = oci_kms_vault.vault[vault_ref].id
-          versions = {for version in key.versions: 
+          versions = { for version in key.versions :
             version => {
-            id = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_version_id
-            key_id = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_id
-            is_primary = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].is_primary
+              id         = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_version_id
+              key_id     = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_id
+              is_primary = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].is_primary
             }
           }
-        }}
+        } }
       }
     }
 
-    file_restored_vaults = { for vault_ref, vault in var.file_restored_vaults: 
+    file_restored_vaults = { for vault_ref, vault in var.file_restored_vaults :
       vault_ref => {
-        id = oci_kms_vault.vault[vault_ref].id
-        crypto_endpoint = oci_kms_vault.vault[vault_ref].crypto_endpoint
-        management_endpoint =  oci_kms_vault.vault[vault_ref].management_endpoint
-        keys = {for key_ref, key in vault.keys: key_ref => {
-          id = oci_kms_key.key["${vault_ref}:${key_ref}"].id
+        id                  = oci_kms_vault.vault[vault_ref].id
+        crypto_endpoint     = oci_kms_vault.vault[vault_ref].crypto_endpoint
+        management_endpoint = oci_kms_vault.vault[vault_ref].management_endpoint
+        keys = { for key_ref, key in vault.keys : key_ref => {
+          id       = oci_kms_key.key["${vault_ref}:${key_ref}"].id
           vault_id = oci_kms_vault.vault[vault_ref].id
-          versions = {for version in key.versions: 
+          versions = { for version in key.versions :
             version => {
-            id = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_version_id
-            key_id = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_id
-            is_primary = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].is_primary
+              id         = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_version_id
+              key_id     = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_id
+              is_primary = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].is_primary
             }
           }
-        }}
+        } }
       }
     }
 
-    object_restored_vaults = { for vault_ref, vault in var.object_store_restored_vaults: 
+    object_restored_vaults = { for vault_ref, vault in var.object_store_restored_vaults :
       vault_ref => {
-        id = oci_kms_vault.vault[vault_ref].id
-        crypto_endpoint = oci_kms_vault.vault[vault_ref].crypto_endpoint
-        management_endpoint =  oci_kms_vault.vault[vault_ref].management_endpoint
-        keys = {for key_ref, key in vault.keys: key_ref => {
-          id = oci_kms_key.key["${vault_ref}:${key_ref}"].id
+        id                  = oci_kms_vault.vault[vault_ref].id
+        crypto_endpoint     = oci_kms_vault.vault[vault_ref].crypto_endpoint
+        management_endpoint = oci_kms_vault.vault[vault_ref].management_endpoint
+        keys = { for key_ref, key in vault.keys : key_ref => {
+          id       = oci_kms_key.key["${vault_ref}:${key_ref}"].id
           vault_id = oci_kms_vault.vault[vault_ref].id
-          versions = {for version in key.versions: 
+          versions = { for version in key.versions :
             version => {
-            id = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_version_id
-            key_id = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_id
-            is_primary = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].is_primary
+              id         = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_version_id
+              key_id     = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_id
+              is_primary = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].is_primary
             }
           }
-        }}
+        } }
       }
     }
   }

--- a/modules/vault/output.tf
+++ b/modules/vault/output.tf
@@ -1,0 +1,60 @@
+output "vaults" {
+  value = {
+    created_vaults = { for vault_ref, vault in var.vaults: 
+      vault_ref => {
+        id = oci_kms_vault.vault[vault_ref].id
+        crypto_endpoint = oci_kms_vault.vault[vault_ref].crypto_endpoint
+        management_endpoint =  oci_kms_vault.vault[vault_ref].management_endpoint
+        keys = {for key_ref, key in vault.keys: key_ref => {
+          id = oci_kms_key.key["${vault_ref}:${key_ref}"].id
+          vault_id = oci_kms_vault.vault[vault_ref].id
+          versions = {for version in key.versions: 
+            version => {
+            id = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_version_id
+            key_id = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_id
+            is_primary = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].is_primary
+            }
+          }
+        }}
+      }
+    }
+
+    file_restored_vaults = { for vault_ref, vault in var.file_restored_vaults: 
+      vault_ref => {
+        id = oci_kms_vault.vault[vault_ref].id
+        crypto_endpoint = oci_kms_vault.vault[vault_ref].crypto_endpoint
+        management_endpoint =  oci_kms_vault.vault[vault_ref].management_endpoint
+        keys = {for key_ref, key in vault.keys: key_ref => {
+          id = oci_kms_key.key["${vault_ref}:${key_ref}"].id
+          vault_id = oci_kms_vault.vault[vault_ref].id
+          versions = {for version in key.versions: 
+            version => {
+            id = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_version_id
+            key_id = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_id
+            is_primary = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].is_primary
+            }
+          }
+        }}
+      }
+    }
+
+    object_restored_vaults = { for vault_ref, vault in var.object_store_restored_vaults: 
+      vault_ref => {
+        id = oci_kms_vault.vault[vault_ref].id
+        crypto_endpoint = oci_kms_vault.vault[vault_ref].crypto_endpoint
+        management_endpoint =  oci_kms_vault.vault[vault_ref].management_endpoint
+        keys = {for key_ref, key in vault.keys: key_ref => {
+          id = oci_kms_key.key["${vault_ref}:${key_ref}"].id
+          vault_id = oci_kms_vault.vault[vault_ref].id
+          versions = {for version in key.versions: 
+            version => {
+            id = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_version_id
+            key_id = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].key_id
+            is_primary = oci_kms_key_version.key_version["${vault_ref}:${key_ref}:${version}"].is_primary
+            }
+          }
+        }}
+      }
+    }
+  }
+}

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -8,7 +8,7 @@ variable "vaults" {
       compartment_id = string
       length = string
       algorithm = string
-      state = string
+      enabled = bool
       mode = string
       versions = set(number)
     }))

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -1,16 +1,16 @@
 variable "vaults" {
   type = map(object({
-    name = string
+    name           = string
     compartment_id = string
-    type = string
+    type           = string
     keys = map(object({
-      name = string
+      name           = string
       compartment_id = string
-      length = string
-      algorithm = string
-      enabled = bool
-      mode = string
-      versions = set(number)
+      length         = string
+      algorithm      = string
+      enabled        = bool
+      mode           = string
+      versions       = set(number)
     }))
   }))
 
@@ -21,22 +21,22 @@ variable "vaults" {
 #TODO v3 support key restoration from file/object storage
 variable "file_restored_vaults" {
   type = map(object({
-    name = string
+    name           = string
     compartment_id = string
-    type = string
+    type           = string
     file = object({
-      length = string
-      md5 = string
+      length  = string
+      md5     = string
       content = string
     })
     keys = map(object({
-      name = string
+      name           = string
       compartment_id = string
-      length = string
-      algorithm = string
-      state = string
-      mode = string
-      versions = set(number)
+      length         = string
+      algorithm      = string
+      enabled        = bool
+      mode           = string
+      versions       = set(number)
     }))
   }))
 
@@ -45,24 +45,24 @@ variable "file_restored_vaults" {
 
 variable "object_store_restored_vaults" {
   type = map(object({
-    name = string
+    name           = string
     compartment_id = string
-    type = string
+    type           = string
     oci_object_store = object({
-      bucket = string
+      bucket      = string
       destination = string
-      namespace = string
-      object = string
-      uri = string
+      namespace   = string
+      object      = string
+      uri         = string
     })
     keys = map(object({
-      name = string
+      name           = string
       compartment_id = string
-      length = string
-      algorithm = string
-      state = string
-      mode = string
-      versions = set(number)
+      length         = string
+      algorithm      = string
+      enabled        = bool
+      mode           = string
+      versions       = set(number)
     }))
   }))
 

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -1,0 +1,67 @@
+variable "vaults" {
+  type = map(object({
+    name = string
+    compartment_id = string
+    type = string
+    keys = map(object({
+      name = string
+      compartment_id = string
+      length = string
+      algorithm = string
+      state = string
+      mode = string
+    }))
+  }))
+
+  default = {}
+}
+
+# when you restore, existing keys must be improted to terraform state manually
+#TODO v3 support key restoration from file/object storage
+variable "file_restored_vaults" {
+  type = map(object({
+    name = string
+    compartment_id = string
+    type = string
+    file = object({
+      content_length = string
+      content_md5 = string
+      content = string
+    })
+    keys = map(object({
+      name = string
+      compartment_id = string
+      length = string
+      algorithm = string
+      state = string
+      mode = string
+    }))
+  }))
+
+  default = {}
+}
+
+variable "object_store_restored_vaults" {
+  type = map(object({
+    name = string
+    compartment_id = string
+    type = string
+    oci_object_store = object({
+      bucket = string
+      destination = string
+      namespace = string
+      object = string
+      uri = string
+    })
+    keys = map(object({
+      name = string
+      compartment_id = string
+      length = string
+      algorithm = string
+      state = string
+      mode = string
+    }))
+  }))
+
+  default = {}
+}

--- a/modules/vault/variables.tf
+++ b/modules/vault/variables.tf
@@ -10,6 +10,7 @@ variable "vaults" {
       algorithm = string
       state = string
       mode = string
+      versions = set(number)
     }))
   }))
 
@@ -24,8 +25,8 @@ variable "file_restored_vaults" {
     compartment_id = string
     type = string
     file = object({
-      content_length = string
-      content_md5 = string
+      length = string
+      md5 = string
       content = string
     })
     keys = map(object({
@@ -35,6 +36,7 @@ variable "file_restored_vaults" {
       algorithm = string
       state = string
       mode = string
+      versions = set(number)
     }))
   }))
 
@@ -60,6 +62,7 @@ variable "object_store_restored_vaults" {
       algorithm = string
       state = string
       mode = string
+      versions = set(number)
     }))
   }))
 

--- a/modules/volumes/README.md
+++ b/modules/volumes/README.md
@@ -2,14 +2,27 @@
 
 Create and manage "Block Volumes" and their backup policies across regions. Read more about Block Volumes [here](https://docs.oracle.com/en-us/iaas/Content/Block/Concepts/overview.htm).
 
+# Volume Attachment
+Once the volume is created, you can attach it to multiple instances. By default the volume will be attached as `paravirtualized`. However you have the option to overwrite this under `volumes[].instances_attachment[].optionals.type`.
+
+## Sharing volume with multiple instances
+Ensure that you turn on the `volumes[].instances_attachment[].is_shareable` to `true`.
+
 # Note about Backup Policy
+OCI already provides its own backup policies. However, this modules DOES NOT support using existing policies. You will have to define the policy in this module to be abl to use it with a volume.
+
+When creating a policy, you need to be careful with `backup_policies[].schedules[].optionals`. Depending on the value of `backup_policies[].schedules[].backup_type` you will need to set the `backup_policies[].schedules[].optionals` values. See example below and refer to (core_volume_backup_policy)[https://registry.terraform.io/providers/hashicorp/oci/latest/docs/resources/core_volume_backup_policy].
 
 # Replication
+The module supports replication across another region. Just set `volumes[].cross_ad_replicas[].destination_availability_domain` and  `volumes[].cross_ad_replicas[].replica_name` as many times as you want. Ensure that you set `volumes[].disable_replicas` to `false`
 
 # Creating Volume from other source
+To create a volume from an existing volume, all you have to do is to set `volumes[].source_volume.id` and `volumes[].source_volume.type`. This makes it possible to clone an existing volume and use it as new one.
 
 # Limitations 
-
+* Using predefined OCI Backup Policy not supported.
+* `offsetSeconds` Backup Policy are NOT supported.
+*  
 # Example
 
 ```js

--- a/modules/volumes/README.md
+++ b/modules/volumes/README.md
@@ -1,0 +1,131 @@
+# Volumes
+
+Create and manage "Block Volumes" and their backup policies across regions. Read more about Block Volumes [here](https://docs.oracle.com/en-us/iaas/Content/Block/Concepts/overview.htm).
+
+# Note about Backup Policy
+
+# Replication
+
+# Creating Volume from other source
+
+# Limitations 
+
+# Example
+
+```js
+module "opensource_volumes" {
+  source          = "github.com/Binsabbar/oracle-cloud-terraform//modules/volumes"
+  volumes         = {
+    "volume-1" = {
+      name                                = "volume-1"
+      compartment_id                      = "oci.xxxxxxxxxxxxxxxxxxx"
+      availability_domain                 = data.oci_identity_availability_domain.ad_1.name
+      size_in_gbs                         = 50
+      reference_to_backup_policy_key_name = null
+      disable_replicas                    = true
+      cross_ad_replicas                   = {
+        "replica-1" = {
+          destination_availability_domain = "me-jeddah-2"
+          replica_name                    = "region-2-replica-volume1" 
+        }
+      }
+      source_volume                       = {
+        id = "oci.volume.xxxxxxxxxxxxxxxxx"
+        type = "volume"
+      }
+      instances_attachment = {
+        "instace-1" = {
+          instance_id  = "oci.instance.xxxxxxxxxxxxx"
+          is_shareable = true
+          optionals    = {}
+        }
+      }
+      optionals = {
+        auto_tuned = true
+        kms_id = "oci.kms.xxxxxxxxxxxxxxxxxxx"
+        vpus_per_gb = 10
+      }
+    }
+    "volume-2" = {
+      name                                = "volume-2"
+      compartment_id                      = "oci.xxxxxxxxxxxxxxxxxxx"
+      availability_domain                 = data.oci_identity_availability_domain.ad_1.name
+      size_in_gbs                         = 50
+      reference_to_backup_policy_key_name = "everyday"
+      disable_replicas                    = true
+      cross_ad_replicas                   = {}
+      source_volume = {}
+      instances_attachment = {
+        "instace-1" = {
+          instance_id  = "oci.instance.xxxxxxxxxxxxx"
+          is_shareable = true
+          optionals    = {
+            type = ""
+            is_read_only = true
+            is_pv_encryption_in_transit_enabled = bool
+            encryption_in_transit_type = string
+            use_chap = bool
+          }
+        }
+        "instace-2" = {
+          instance_id  = "oci.instance.xxxxxxxxxxxxx"
+          is_shareable = false
+          optionals    = {
+            type = ""
+            is_read_only = false
+            is_pv_encryption_in_transit_enabled = true
+          }
+        }
+      }
+      optionals = {}
+    }
+  }
+  backup_policies = {
+    "SLA-1" = {
+      compartment_id = "oci.xxxxxxxxxxxxxxxxxxxxx"
+      name = "SLA Level 1 backup policy"
+      destination_region = "me-jeddah-1"
+      schedules = { 
+        "daily" = {
+          backup_type = "INCREMENTAL"
+          period = "ONE_DAY"
+          retention_seconds = 3600 * 24 # one day
+          optionals = {
+            hour_of_day = 23
+          }
+        }
+        "weekly" = {
+          backup_type = "FULL"
+          period = "ONE_WEEK"
+          retention_seconds = 3600 * 24 * 7 # one week
+          optionals = {
+            hour_of_day = 0
+            day_of_week = "FRIDAY"
+          }
+        }
+        "monthly" = {
+          backup_type = "FULL"
+          period = "ONE_MONTH"
+          retention_seconds = 3600 * 24 * 30 # # one month
+          optionals = {
+            hour_of_day = 0
+            day_of_week = "SUNDAY"
+            day_of_month = 28
+          }
+        }
+        "yearly" = {
+          backup_type = "FULL"
+          period = "ONE_YEAR"
+          retention_seconds = 3600 * 24 * 30 * 12 # # one year
+          optionals = {
+            hour_of_day = 0
+            day_of_week = "SUNDAY"
+            day_of_month = 30
+            month = "DECEMBER"
+          }
+        }
+      }
+    }
+  }
+}
+```

--- a/modules/volumes/main.tf
+++ b/modules/volumes/main.tf
@@ -85,11 +85,13 @@ resource "oci_core_volume_backup_policy" "volume_backup_policy" {
 }
 
 
-# // Policy Attachment
-# resource "oci_core_volume_backup_policy_assignment" "volume_backup_policy_assignment" {
-#     asset_id = oci_core_volume.test_volume.id
-#     policy_id = oci_core_volume_backup_policy.test_volume_backup_policy.id
-# }
+// Policy Attachment
+resource "oci_core_volume_backup_policy_assignment" "volume_backup_policy_assignment" {
+  for_each = { for volume_k, volume_v in var.volumes : volume_k => volume_v if volume_v.reference_to_backup_policy_key_name != null }
+
+  asset_id  = oci_core_volume.volume[each.key].id
+  policy_id = oci_core_volume_backup_policy.volume_backup_policy[each.value.reference_to_backup_policy_key_name].id
+}
 
 # // Group
 # resource "oci_core_volume_group" "test_volume_group" {

--- a/modules/volumes/main.tf
+++ b/modules/volumes/main.tf
@@ -92,23 +92,3 @@ resource "oci_core_volume_backup_policy_assignment" "volume_backup_policy_assign
   asset_id  = oci_core_volume.volume[each.key].id
   policy_id = oci_core_volume_backup_policy.volume_backup_policy[each.value.reference_to_backup_policy_key_name].id
 }
-
-# // Group
-# resource "oci_core_volume_group" "test_volume_group" {
-#     availability_domain = var.volume_group_availability_domain
-#     compartment_id = var.compartment_id
-#     display_name = var.volume_group_display_name
-#     backup_policy_id = data.oci_core_volume_backup_policies.test_volume_backup_policies.volume_backup_policies.0.id
-#     source_details {
-#         type = "volumeIds"
-#         volume_ids = [var.volume_group_source_id]
-#     }
-# }
-
-# // Group backup
-# resource "oci_core_volume_group_backup" "volume_group_backup" {
-#     volume_group_id = oci_core_volume_group.test_volume_group.id
-#     compartment_id = var.compartment_id
-#     display_name = var.volume_group_backup_display_name
-#     type = var.volume_group_backup_type
-# }

--- a/modules/volumes/main.tf
+++ b/modules/volumes/main.tf
@@ -29,7 +29,7 @@ resource "oci_core_volume" "volume" {
   }
 
   dynamic "source_details" {
-    for_each = each.value.cloned ? each.value.source_volume : []
+    for_each = length(each.value.source_volume) != 0 ? [each.value.source_volume] : []
     content {
       id   = source_details.value.id
       type = source_details.value.type
@@ -61,6 +61,7 @@ resource "oci_core_volume_attachment" "volume_attachment" {
 #         backup_type = var.volume_backup_policy_schedules_backup_type
 #         period = var.volume_backup_policy_schedules_period
 #         retention_seconds = var.volume_backup_policy_schedules_retention_seconds
+
 #         day_of_month = var.volume_backup_policy_schedules_day_of_month
 #         day_of_week = var.volume_backup_policy_schedules_day_of_week
 #         hour_of_day = var.volume_backup_policy_schedules_hour_of_day

--- a/modules/volumes/main.tf
+++ b/modules/volumes/main.tf
@@ -4,6 +4,13 @@ locals {
       for attch_k, attach_v in vol_v.instances_attachment : "${vol_k}-${attch_k}" => merge(attach_v, { volume_key = vol_k })
     }
   ]...)
+
+  does_reference_to_backup_policy_key_name_exist = alltrue([ for k, v in var.volumes : v.reference_to_backup_policy_key_name != null? contains(keys(var.backup_policies), v.reference_to_backup_policy_key_name):true ])
+}
+
+// Error Checking if reference_to_backup_policy_key_name exists in var.backup_policies (work around described here https://github.com/hashicorp/terraform/issues/15469#issuecomment-814789329)
+resource "null_resource" "does_reference_to_backup_policy_key_name_exist" {
+  count = local.does_reference_to_backup_policy_key_name_exist ? 0 : "ERROR: volumes.*.reference_to_backup_policy_key_name must exist in var.backup_policies"
 }
 
 // Volume

--- a/modules/volumes/main.tf
+++ b/modules/volumes/main.tf
@@ -1,0 +1,141 @@
+variable "volumes" {
+  type = map(object({
+    name = string
+    compartment_id = string
+    availability_domain = string
+    size_in_gbs = string
+    disable_replicas = bool
+    cross_ad_replicas = map(object({
+      destination_availability_domain = string
+      replica_name = string
+    }))
+    cloned  = bool
+    source_volume = list(object({
+      id = string
+      type = string
+    }))
+    optionals = map(string)
+    # kms_id
+    # auto_tuned
+    # vpus_per_gb
+  }))
+
+  
+  validation {
+    condition = alltrue([
+      for k, v in var.volumes:
+      length(v.source_volume) < 2
+    ])
+    error_message = "The volumes.*.source_volume cannot contain more than 1 value."
+  }
+  
+  validation {
+    condition = alltrue(flatten([
+      for k, v in var.volumes: [
+        for option in keys(v.optionals): contains(["kms_id", "auto_tuned", "vpus_per_gb"], option)
+      ]
+    ]))
+    error_message = "The volumes.*.optionals accepts \"kms_id\", \"auto_tuned\", \"vpus_per_gb\"."
+  }
+}
+
+// Volume
+resource "oci_core_volume" "volume" {
+    for_each = var.volumes
+
+    compartment_id = each.value.compartment_id
+    availability_domain = each.value.availability_domain
+    display_name = each.value.name
+    size_in_gbs = each.value.size_in_gbs
+    
+    kms_key_id = lookup(each.value.optionals, "kms_id", "")
+    is_auto_tune_enabled = lookup(each.value.optionals, "auto_tuned", "true")
+    vpus_per_gb = lookup(each.value.optionals, "vpus_per_gb", "20")
+    
+    block_volume_replicas_deletion = each.value.disable_replicas
+    dynamic "block_volume_replicas" {
+      for_each = each.value.disable_replicas ? {} : each.value.cross_region_replica
+      content {
+        availability_domain = block_volume_replicas.value.replica_region
+        display_name = block_volume_replicas.value.replica_name
+      }
+    }
+    
+    dynamic "source_details" {
+      for_each = each.value.cloned ? each.value.source_volume:[]
+      content {
+        id = source_details.value.id
+        type = source_details.value.type
+      }
+    }
+}
+
+
+
+// Attachment 
+# resource "oci_core_volume_attachment" "volume_paravirtualized_attachment" {
+#     attachment_type = value.attachment_type
+#     instance_id = each.value.instance_id
+#     volume_id = oci_core_volume.volume.id
+#     display_name = each.key
+#     is_read_only = each.value.is_read_only
+#     is_shareable = each.value.is_shareable    
+#     is_pv_encryption_in_transit_enabled =  each.value.is_pv_encryption_in_transit_enabled
+# }
+
+# resource "oci_core_volume_attachment" "volume_attachment" {
+#     attachment_type = value.attachment_type
+#     instance_id = each.value.instance_id
+#     volume_id = oci_core_volume.volume.id
+#     display_name = each.key
+#     is_read_only = each.value.is_read_only
+#     is_shareable = each.value.is_shareable
+#     encryption_in_transit_type = lookup("", "NONE")
+#     use_chap = each.value.use_chap
+# }
+
+# // Backup Policy
+# resource "oci_core_volume_backup_policy" "volume_backup_policy" {
+#     compartment_id = var.compartment_id
+#     destination_region = var.volume_backup_policy_destination_region
+#     display_name = var.volume_backup_policy_display_name
+#     schedules {
+#         backup_type = var.volume_backup_policy_schedules_backup_type
+#         period = var.volume_backup_policy_schedules_period
+#         retention_seconds = var.volume_backup_policy_schedules_retention_seconds
+#         day_of_month = var.volume_backup_policy_schedules_day_of_month
+#         day_of_week = var.volume_backup_policy_schedules_day_of_week
+#         hour_of_day = var.volume_backup_policy_schedules_hour_of_day
+#         month = var.volume_backup_policy_schedules_month
+#         offset_seconds = var.volume_backup_policy_schedules_offset_seconds
+#         offset_type = var.volume_backup_policy_schedules_offset_type
+#         time_zone = var.volume_backup_policy_schedules_time_zone
+#     }
+# }
+
+
+# // Policy Attachment
+# resource "oci_core_volume_backup_policy_assignment" "volume_backup_policy_assignment" {
+#     asset_id = oci_core_volume.test_volume.id
+#     policy_id = oci_core_volume_backup_policy.test_volume_backup_policy.id
+# }
+
+# // Group
+# resource "oci_core_volume_group" "test_volume_group" {
+#     availability_domain = var.volume_group_availability_domain
+#     compartment_id = var.compartment_id
+#     display_name = var.volume_group_display_name
+#     backup_policy_id = data.oci_core_volume_backup_policies.test_volume_backup_policies.volume_backup_policies.0.id
+#     source_details {
+#         type = "volumeIds"
+#         volume_ids = [var.volume_group_source_id]
+#     }
+# }
+
+# // Group backup
+# resource "oci_core_volume_group_backup" "volume_group_backup" {
+#     volume_group_id = oci_core_volume_group.test_volume_group.id
+#     compartment_id = var.compartment_id
+#     display_name = var.volume_group_backup_display_name
+#     type = var.volume_group_backup_type
+# }

--- a/modules/volumes/variables.tf
+++ b/modules/volumes/variables.tf
@@ -5,38 +5,33 @@ variable "volumes" {
     availability_domain = string
     size_in_gbs         = string
     disable_replicas    = bool
+    reference_to_backup_policy_key_name = string
     cross_ad_replicas = map(object({
       destination_availability_domain = string
       replica_name                    = string
     }))
-    cloned = bool
-    source_volume = list(object({
-      id   = string
-      type = string
-    }))
+    source_volume = map(string)
+      # id   = string
+      # type = string
     instances_attachment = map(object({
       instance_id  = string
       is_shareable = bool
       optionals    = map(string)
-      # type = string
-      # is_read_only = bool
-      # is_pv_encryption_in_transit_enabled = bool
-      # encryption_in_transit_type = string
-      # use_chap = bool
+        # type = string
+        # is_read_only = bool
+        # is_pv_encryption_in_transit_enabled = bool
+        # encryption_in_transit_type = string
+        # use_chap = bool
     }))
     optionals = map(string)
-    # kms_id = string
-    # auto_tuned = bool
-    # vpus_per_gb = number
+      # kms_id = string
+      # auto_tuned = bool
+      # vpus_per_gb = number
   }))
 
-
   validation {
-    condition = alltrue([
-      for k, v in var.volumes :
-      length(v.source_volume) < 2
-    ])
-    error_message = "The volumes.*.source_volume cannot contain more than 1 value."
+    condition = alltrue(flatten([for k, v in var.volumes : [for source_volume_key in keys(v.source_volume): contains(["id", "type"], source_volume_key)]]))
+    error_message = "The volumes.*.source_volume must be map consisting of the following two keys \"id\" and \"type\"."
   }
 
   validation {

--- a/modules/volumes/variables.tf
+++ b/modules/volumes/variables.tf
@@ -1,27 +1,27 @@
 variable "backup_policies" {
   type = map(object({
-    compartment_id = string
-    name = string
-    region = string
-    schedules = object({
-      type = string
-      period = string
+    compartment_id     = string
+    name               = string
+    destination_region = string
+    schedules = map(object({
+      backup_type       = string
+      period            = string
       retention_seconds = number
-      optionals = map(string)
+      optionals         = map(string)
       # day_of_month 
       # day_of_week
       # hour_of_day
       # month
-      # offset_seconds
-      # offset_type
       # time_zone
-    })
+    }))
   }))
 
   validation {
     condition = alltrue(flatten([
       for k, v in var.backup_policies : [
-        for option in keys(v.schedules.optionals) : contains(["day_of_month", "day_of_week", "hour_of_day", "month", "offset_seconds", "offset_type", "zone"], option)
+        for kk, schedule in v.schedules : [
+          for option in keys(schedule.optionals) : contains(["day_of_month", "day_of_week", "hour_of_day", "month", "zone"], option)
+        ]
       ]
     ]))
     error_message = "The var.backup_policies.*.schedules.optionals accepts \"day_of_month\", \"day_of_week\", \"hour_of_day\", \"month\", \"offset_seconds\", \"offset_type\", \"zone\"."
@@ -30,37 +30,37 @@ variable "backup_policies" {
 
 variable "volumes" {
   type = map(object({
-    name                = string
-    compartment_id      = string
-    availability_domain = string
-    size_in_gbs         = string
-    disable_replicas    = bool
-    reference_to_backup_policy_key_name = string  # The name of the key in var.backup_policies
+    name                                = string
+    compartment_id                      = string
+    availability_domain                 = string
+    size_in_gbs                         = string
+    disable_replicas                    = bool
+    reference_to_backup_policy_key_name = string # The name of the key in var.backup_policies
     cross_ad_replicas = map(object({
       destination_availability_domain = string
       replica_name                    = string
     }))
     source_volume = map(string)
-      # id   = string
-      # type = string
+    # id   = string
+    # type = string
     instances_attachment = map(object({
       instance_id  = string
       is_shareable = bool
       optionals    = map(string)
-        # type = string
-        # is_read_only = bool
-        # is_pv_encryption_in_transit_enabled = bool
-        # encryption_in_transit_type = string
-        # use_chap = bool
+      # type = string
+      # is_read_only = bool
+      # is_pv_encryption_in_transit_enabled = bool
+      # encryption_in_transit_type = string
+      # use_chap = bool
     }))
     optionals = map(string)
-      # kms_id = string
-      # auto_tuned = bool
-      # vpus_per_gb = number
+    # kms_id = string
+    # auto_tuned = bool
+    # vpus_per_gb = number
   }))
 
   validation {
-    condition = alltrue(flatten([for k, v in var.volumes : [for source_volume_key in keys(v.source_volume): contains(["id", "type"], source_volume_key)]]))
+    condition     = alltrue(flatten([for k, v in var.volumes : [for source_volume_key in keys(v.source_volume) : contains(["id", "type"], source_volume_key)]]))
     error_message = "The volumes.*.source_volume must be map consisting of the following two keys \"id\" and \"type\"."
   }
 

--- a/modules/volumes/variables.tf
+++ b/modules/volumes/variables.tf
@@ -1,0 +1,60 @@
+variable "volumes" {
+  type = map(object({
+    name                = string
+    compartment_id      = string
+    availability_domain = string
+    size_in_gbs         = string
+    disable_replicas    = bool
+    cross_ad_replicas = map(object({
+      destination_availability_domain = string
+      replica_name                    = string
+    }))
+    cloned = bool
+    source_volume = list(object({
+      id   = string
+      type = string
+    }))
+    instances_attachment = map(object({
+      instance_id  = string
+      is_shareable = bool
+      optionals    = map(string)
+      # type = string
+      # is_read_only = bool
+      # is_pv_encryption_in_transit_enabled = bool
+      # encryption_in_transit_type = string
+      # use_chap = bool
+    }))
+    optionals = map(string)
+    # kms_id = string
+    # auto_tuned = bool
+    # vpus_per_gb = number
+  }))
+
+
+  validation {
+    condition = alltrue([
+      for k, v in var.volumes :
+      length(v.source_volume) < 2
+    ])
+    error_message = "The volumes.*.source_volume cannot contain more than 1 value."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for k, v in var.volumes : [
+        for i_k, i_v in v.instances_attachment : [
+        for option in keys(i_v.optionals) : contains(["type", "is_read_only", "is_pv_encryption_in_transit_enabled", "encryption_in_transit_type", "use_chap"], option)]
+      ]
+    ]))
+    error_message = "The volumes.*.instnaces_attachment.*.optionals accepts \"type\", \"is_read_only\", \"is_pv_encryption_in_transit_enabled\", \"encryption_in_transit_type\", \"use_chap\"."
+  }
+
+  validation {
+    condition = alltrue(flatten([
+      for k, v in var.volumes : [
+        for option in keys(v.optionals) : contains(["kms_id", "auto_tuned", "vpus_per_gb"], option)
+      ]
+    ]))
+    error_message = "The volumes.*.optionals accepts \"kms_id\", \"auto_tuned\", \"vpus_per_gb\"."
+  }
+}

--- a/modules/volumes/variables.tf
+++ b/modules/volumes/variables.tf
@@ -11,7 +11,7 @@ variable "backup_policies" {
       # day_of_month 
       # day_of_week
       # hour_of_day
-      # month
+      # month 
       # time_zone
     }))
   }))

--- a/modules/volumes/variables.tf
+++ b/modules/volumes/variables.tf
@@ -26,6 +26,22 @@ variable "backup_policies" {
     ]))
     error_message = "The var.backup_policies.*.schedules.optionals accepts \"day_of_month\", \"day_of_week\", \"hour_of_day\", \"month\", \"offset_seconds\", \"offset_type\", \"zone\"."
   }
+
+  description = <<EOF
+    compartment_id     : which compartment to create the volume in
+    name               : policy name
+    destination_region : Backup destination region for this policy
+    schedules          : map of backup scheduling configuration
+      backup_type       : type of the backup (INCREMENTAL, FULL)
+      period            : backup frequency (ONE_DAY, ONE_WEEK, ONE_MONTH, ONE_YEAR)
+      retention_seconds : for how long to keep the backup for?
+      optionals         : map of extra optional schedules configuration 
+        day_of_month (Default: `1`)
+        day_of_week  (Default: `MONDAY`)
+        hour_of_day  (Default: `0`)
+        month        (Default: `JANUARY`)
+        time_zone    (Default: `UTC`) : Support either `UTC` or `REGIONAL_DATA_CENTER_TIME`
+  EOF
 }
 
 variable "volumes" {
@@ -82,4 +98,32 @@ variable "volumes" {
     ]))
     error_message = "The volumes.*.optionals accepts \"kms_id\", \"auto_tuned\", \"vpus_per_gb\"."
   }
+
+  description = <<EOF
+    name                                : name of the oci volume
+    compartment_id                      : which compartment to create the volume in
+    availability_domain                 : in which availability domain to create the volume
+    size_in_gbs                         : volume size in GB
+    disable_replicas                    : wether to enable or disable replication of volume accross other availability domain
+    reference_to_backup_policy_key_name : name of the backup policy key in var.backup_policies (Leave Empty is no backup is required)
+    cross_ad_replicas                   : Map of replicas configuration. You can have multiple replication 
+      destination_availability_domain : name of the availability domain
+      replica_name                    : name of the replica 
+    source_volume: map of source volume configuration
+      id   : the ocid of the target source 
+      type : type of the source (volume, bootvolume). Check OCI docs for supported types
+    instances_attachment : map of instance attachements configurations
+      instance_id  : ocid of the instance
+      is_shareable : where to make this attachment shareable or not. Check OCI docs for sharable volumes
+      optionals    : map of optional values to overwirte for instance attachments (leave empty to use default value {})
+        type                                (Default: `paravirtualized`)                     
+        is_read_only                        (Default: `false`)
+        is_pv_encryption_in_transit_enabled (Default: `false`) 
+        encryption_in_transit_type          (default: `NONE`)
+        use_chap                            (Default: `false`)
+    optionals : map of optional values for volumes configuration (leave empty to use default value {})
+      kms_id      (Default: '')
+      auto_tuned  (Default: `true`)
+      vpus_per_gb (Default: `20`)
+  EOF
 }

--- a/modules/volumes/variables.tf
+++ b/modules/volumes/variables.tf
@@ -1,3 +1,33 @@
+variable "backup_policies" {
+  type = map(object({
+    compartment_id = string
+    name = string
+    region = string
+    schedules = object({
+      type = string
+      period = string
+      retention_seconds = number
+      optionals = map(string)
+      # day_of_month 
+      # day_of_week
+      # hour_of_day
+      # month
+      # offset_seconds
+      # offset_type
+      # time_zone
+    })
+  }))
+
+  validation {
+    condition = alltrue(flatten([
+      for k, v in var.backup_policies : [
+        for option in keys(v.schedules.optionals) : contains(["day_of_month", "day_of_week", "hour_of_day", "month", "offset_seconds", "offset_type", "zone"], option)
+      ]
+    ]))
+    error_message = "The var.backup_policies.*.schedules.optionals accepts \"day_of_month\", \"day_of_week\", \"hour_of_day\", \"month\", \"offset_seconds\", \"offset_type\", \"zone\"."
+  }
+}
+
 variable "volumes" {
   type = map(object({
     name                = string
@@ -5,7 +35,7 @@ variable "volumes" {
     availability_domain = string
     size_in_gbs         = string
     disable_replicas    = bool
-    reference_to_backup_policy_key_name = string
+    reference_to_backup_policy_key_name = string  # The name of the key in var.backup_policies
     cross_ad_replicas = map(object({
       destination_availability_domain = string
       replica_name                    = string

--- a/releases.md
+++ b/releases.md
@@ -2,6 +2,9 @@
 ## _**Breaking Changes**_
 * `object-storage` module input is updated to include configuration for `lifecycle` managements.
   * Add the following key to every bucket created `lifecycle-rules = {}`. To configure rules, refer to module's readme.
+* `network` module input is updated as following:
+  * `allowed_ingress_ports` is removed and replaced by the new key `tcp_ingress_ports_from_all` in `default_security_list_rules.public_subnets`.
+    * `allowed_ingress_ports` was applied only to **public subnet security list** as TCP ingress. Whatever value you had there add it to `default_security_list_rules.public_subnets.tcp_ingress_ports_from_all`
 
 ## **New** 
 * Add `vault` module to manage KMS (only key management is enabled)

--- a/releases.md
+++ b/releases.md
@@ -5,11 +5,41 @@
 * `network` module input is updated as following:
   * `allowed_ingress_ports` is removed and replaced by the new key `tcp_ingress_ports_from_all` in `default_security_list_rules.public_subnets`.
     * `allowed_ingress_ports` was applied only to **public subnet security list** as TCP ingress. Whatever value you had there add it to `default_security_list_rules.public_subnets.tcp_ingress_ports_from_all`
-
+* `instances` modules input is updated as following:
+  * `config` object has new attribute `primary_vnic`.
+    * Add the following when upgrading to fix it.
+    ```
+    ...
+    ...
+    config = { 
+      primary_vnic = { 
+        primary_ip = "", 
+        secondary_ips = {}
+      }
+    }
+    ...
+    ...
+    ```
+  * `secondary_vnics` is new attribute to instance object.
+    * Add the following to instance object.
+    ```
+    {
+      ...
+      ...
+      config = {
+      ...
+      ...
+      }
+      secondary_vnics = {}
+      ...
+      ...
+    }
+    ```
 ## **New** 
 * Add `vault` module to manage KMS (only key management is enabled)
-* (object-storage) Allow to add `lifecycle-rules` to buckets.
-
+* (`object-storage`) Allow to add `lifecycle-rules` to buckets.
+* (`instance`) Ability to add multiple secondary IPs to primary VNIC
+* (`instance`) Ability to add multiple secondary VNICs and multiple private IPs
 ## **Enhancement**
 * (instances) Allow rename of instance withour recration (breaking change)
   * You need to add `name` attribute to the instance objects you already created.

--- a/releases.md
+++ b/releases.md
@@ -61,7 +61,9 @@
 * (`instance`) Ability to add multiple secondary IPs to primary VNIC
 * (`instance`) Ability to add multiple secondary VNICs and multiple private IPs
 * (`public-ip`) Ability to attach public ip to a given private IP
-* (`network`) Ability to configure `NAT Gateway` (block traffic, assign reserved public IP)
+* (`network`) Ability to 
+  * configure `NAT Gateway` (block traffic, assign reserved public IP)
+  * configure `Internet Gateway` (enable/disable gateway)
 
 ## **Enhancement**
 * (instances) Allow rename of instance withour recration (breaking change)

--- a/releases.md
+++ b/releases.md
@@ -1,13 +1,13 @@
 # V2:
-**Breaking Changes***
+## _**Breaking Changes**_
 * `object-storage` module input is updated to include configuration for `lifecycle` managements.
   * Add the following key to every bucket created `lifecycle-rules = {}`. To configure rules, refer to module's readme.
 
-## New
+## **New** 
 * Add `vault` module to manage KMS (only key management is enabled)
 * (object-storage) Allow to add `lifecycle-rules` to buckets.
 
-## Enhancement
+## **Enhancement**
 * (instances) Allow rename of instance withour recration (breaking change)
   * You need to add `name` attribute to the instance objects you already created.
 * (network) Allow display name of subnet to be updated (breaking change)

--- a/releases.md
+++ b/releases.md
@@ -1,0 +1,10 @@
+# V2:
+**Breaking Changes***
+
+## New
+* Add `vault` module to manage KMS (only key management is enabled)
+
+## Enhancement
+* Allow rename of instance withour recration (breaking change)
+  * You need to add `name` attribute to the instance objects you already created.
+* 

--- a/releases.md
+++ b/releases.md
@@ -1,7 +1,7 @@
 # V2:
 ## _**Breaking Changes**_
 * `public_ip` module input name is changed from `ips` to `untracked_ips`.
-  * This is to distinguish public IPs that will be managed by Terraform. 
+  * This is to distinguish public IPs that will be managed by Terraform (private IP assignment are not tracked by Terraform). This is used in service like `NLB`. 
   * output of module changed. Previously named `ips` renamed to `untracked_ips`
 * `object-storage` module input is updated to include configuration for `lifecycle` managements.
   * Add the following key to every bucket created `lifecycle-rules = {}`. To configure rules, refer to module's readme.
@@ -28,7 +28,7 @@
   terraform state mv module.NETWORK_MODULE_NAME.oci_core_route_table.private_route_table module.NETWORK_MODULE_NAME.oci_core_route_table.private_route_table\[\"natgw=true:svcgw=false\"\]
   ```
 * `instances` modules output is updated:
-  * `public_ip` and `private_ip`, and `private_ip` is renamed to `ip_address`:
+  * `public_ip` and `private_ip` changed to include vnic info, and primary ip. Also `private_ip` is renamed to `ip_address`:
   ```
   "primary_vnic" = {
       "primary_ip" = {
@@ -74,6 +74,12 @@
       ...
     }
     ```
+* (`kubernetes`) The following new variables are added. 
+  * `k8s_version` is renamed to `cluster_k8s_version`
+  * `node_pools[].volume_size_in_gbs`: Set it to `50` to keep current configuration as is.
+  * `node_pools[].k8s_version`: Set it to the previous value of `k8s_version` to keep current configuration as is.
+  * `node_pools[].flex_shape_config`: Set it to `{}`
+  
 ## **New** 
 * Add `vault` module to manage KMS (only key management is enabled)
 * (`object-storage`) Allow to add `lifecycle-rules` to buckets.
@@ -84,9 +90,13 @@
   * configure `NAT Gateway` (enable/disable, block traffic, assign reserved public IP)
   * configure `Internet Gateway` (enable/disable gateway)
   * Create `Service Gateway`.
+* (`kubernetes`) Ability to use `Flex Shape`
+* (`kubernetes`) Ability to change node volume size
+
 
 ## **Enhancement**
-* (instances) Allow rename of instance withour recration (breaking change)
+* (`instances`) Allow rename of instance withour recration (breaking change)
   * You need to add `name` attribute to the instance objects you already created.
-* (network) Allow display name of subnet to be updated (breaking change)
+* (`network`) Allow display name of subnet to be updated (breaking change)
   * You need to add `name` attribute to the subnet objects you already created.
+* (`kuberentes`) Ability to set master node version separately from node pool version.

--- a/releases.md
+++ b/releases.md
@@ -1,6 +1,6 @@
 # V2:
 ## _**Breaking Changes**_
-* `public_ip` module input name is changed from 'ips` to `untracked_ips`.
+* `public_ip` module input name is changed from `ips` to `untracked_ips`.
   * This is to distinguish public IPs that will be managed by Terraform. 
   * output of module changed. Previously named `ips` renamed to `untracked_ips`
 * `object-storage` module input is updated to include configuration for `lifecycle` managements.
@@ -8,6 +8,25 @@
 * `network` module input is updated as following:
   * `allowed_ingress_ports` is removed and replaced by the new key `tcp_ingress_ports_from_all` in `default_security_list_rules.public_subnets`.
     * `allowed_ingress_ports` was applied only to **public subnet security list** as TCP ingress. Whatever value you had there add it to `default_security_list_rules.public_subnets.tcp_ingress_ports_from_all`
+  * `tcp_ingress_ports_from_vcn` and `udp_ingress_ports_from_vcn` are added to `default_security_list_rules.private_subnets`
+  * NAT Gateway and Internet Gateway resource name has changed. Run the following command manually to update the state names
+  
+  Internet Gateway Resource 
+  ```
+  terraform state mv module.NETWORK_MODULE_NAME.oci_core_internet_gateway mv module.module.NETWORK_MODULE_NAME.oci_core_internet_gateway\[0\]
+  ```
+  Nat Gateway Resource 
+  ```
+  terraform state mv module.NETWORK_MODULE_NAME.oci_core_nat_gateway mv module.module.NETWORK_MODULE_NAME.oci_core_nat_gateway\[0\]
+  ```
+  Public Route Table Resource 
+  ```
+  terraform state mv module.NETWORK_MODULE_NAME.oci_core_default_route_table.public_route_table module.NETWORK_MODULE_NAME.oci_core_default_route_table.public_route_table\[\"igw=true\"\]
+  ```
+  Private Route Table Resource
+  ```
+  terraform state mv module.NETWORK_MODULE_NAME.oci_core_route_table.private_route_table module.NETWORK_MODULE_NAME.oci_core_route_table.private_route_table\[\"natgw=true:svcgw=false\"\]
+  ```
 * `instances` modules output is updated:
   * `public_ip` and `private_ip`, and `private_ip` is renamed to `ip_address`:
   ```
@@ -32,10 +51,10 @@
     ...
     ...
     config = { 
-      primary_vnic = { 
+      primary_vnic = {  <------ this line start
         primary_ip = "", 
         secondary_ips = {}
-      }
+      } <------ this line end
     }
     ...
     ...
@@ -50,7 +69,7 @@
       ...
       ...
       }
-      secondary_vnics = {}
+      secondary_vnics = {} <------ this line
       ...
       ...
     }
@@ -62,8 +81,9 @@
 * (`instance`) Ability to add multiple secondary VNICs and multiple private IPs
 * (`public-ip`) Ability to attach public ip to a given private IP
 * (`network`) Ability to 
-  * configure `NAT Gateway` (block traffic, assign reserved public IP)
+  * configure `NAT Gateway` (enable/disable, block traffic, assign reserved public IP)
   * configure `Internet Gateway` (enable/disable gateway)
+  * Create `Service Gateway`.
 
 ## **Enhancement**
 * (instances) Allow rename of instance withour recration (breaking change)

--- a/releases.md
+++ b/releases.md
@@ -61,6 +61,7 @@
 * (`instance`) Ability to add multiple secondary IPs to primary VNIC
 * (`instance`) Ability to add multiple secondary VNICs and multiple private IPs
 * (`public-ip`) Ability to attach public ip to a given private IP
+* (`network`) Ability to configure `NAT Gateway` (block traffic, assign reserved public IP)
 
 ## **Enhancement**
 * (instances) Allow rename of instance withour recration (breaking change)

--- a/releases.md
+++ b/releases.md
@@ -5,6 +5,7 @@
 * Add `vault` module to manage KMS (only key management is enabled)
 
 ## Enhancement
-* Allow rename of instance withour recration (breaking change)
+* (instances) Allow rename of instance withour recration (breaking change)
   * You need to add `name` attribute to the instance objects you already created.
-* 
+* (network) Allow display name of subnet to be updated (breaking change)
+  * You need to add `name` attribute to the subnet objects you already created.

--- a/releases.md
+++ b/releases.md
@@ -1,8 +1,11 @@
 # V2:
 **Breaking Changes***
+* `object-storage` module input is updated to include configuration for `lifecycle` managements.
+  * Add the following key to every bucket created `lifecycle-rules = {}`. To configure rules, refer to module's readme.
 
 ## New
 * Add `vault` module to manage KMS (only key management is enabled)
+* (object-storage) Allow to add `lifecycle-rules` to buckets.
 
 ## Enhancement
 * (instances) Allow rename of instance withour recration (breaking change)

--- a/releases.md
+++ b/releases.md
@@ -8,6 +8,23 @@
 * `network` module input is updated as following:
   * `allowed_ingress_ports` is removed and replaced by the new key `tcp_ingress_ports_from_all` in `default_security_list_rules.public_subnets`.
     * `allowed_ingress_ports` was applied only to **public subnet security list** as TCP ingress. Whatever value you had there add it to `default_security_list_rules.public_subnets.tcp_ingress_ports_from_all`
+* `instances` modules output is updated:
+  * `public_ip` and `private_ip`, and `private_ip` is renamed to `ip_address`:
+  ```
+  "primary_vnic" = {
+      "primary_ip" = {
+        "id" = "ocid1.privateip.oc1.xxxxxxxxxxxxxxxx"
+        "ip_address" = "xxx.xxx.xxx.xxx"
+        "public_ip" = "xxx.xxx.xxx.xxx"
+        "subnet_id" = "ocid1.subnet.oc1.xxxxxxxxxxxxxxx"
+        "vnic_id" = "ocid1.vnic.oc1.xxxxxxxxxxxxxxx"
+      }
+      "secondary_ips" = {
+        ...
+        ...
+      }
+  }
+  ```
 * `instances` modules input is updated as following:
   * `config` object has new attribute `primary_vnic`.
     * Add the following when upgrading to fix it.

--- a/releases.md
+++ b/releases.md
@@ -92,7 +92,7 @@
   * Create `Service Gateway`.
 * (`kubernetes`) Ability to use `Flex Shape`
 * (`kubernetes`) Ability to change node volume size
-
+* (`identity`) Ability to map IdP groups to oci groups.
 
 ## **Enhancement**
 * (`instances`) Allow rename of instance withour recration (breaking change)

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,8 @@
 # V2:
 ## _**Breaking Changes**_
+* `public_ip` module input name is changed from 'ips` to `untracked_ips`.
+  * This is to distinguish public IPs that will be managed by Terraform. 
+  * output of module changed. Previously named `ips` renamed to `untracked_ips`
 * `object-storage` module input is updated to include configuration for `lifecycle` managements.
   * Add the following key to every bucket created `lifecycle-rules = {}`. To configure rules, refer to module's readme.
 * `network` module input is updated as following:
@@ -40,6 +43,8 @@
 * (`object-storage`) Allow to add `lifecycle-rules` to buckets.
 * (`instance`) Ability to add multiple secondary IPs to primary VNIC
 * (`instance`) Ability to add multiple secondary VNICs and multiple private IPs
+* (`public-ip`) Ability to attach public ip to a given private IP
+
 ## **Enhancement**
 * (instances) Allow rename of instance withour recration (breaking change)
   * You need to add `name` attribute to the instance objects you already created.


### PR DESCRIPTION
# V2:
## _**Breaking Changes**_
* `public_ip` module input name is changed from `ips` to `untracked_ips`.
  * This is to distinguish public IPs that will be managed by Terraform (private IP assignment are not tracked by Terraform). This is used in service like `NLB`. 
  * output of module changed. Previously named `ips` renamed to `untracked_ips`
* `object-storage` module input is updated to include configuration for `lifecycle` managements.
  * Add the following key to every bucket created `lifecycle-rules = {}`. To configure rules, refer to module's readme.
* `network` module input is updated as following:
  * `allowed_ingress_ports` is removed and replaced by the new key `tcp_ingress_ports_from_all` in `default_security_list_rules.public_subnets`.
    * `allowed_ingress_ports` was applied only to **public subnet security list** as TCP ingress. Whatever value you had there add it to `default_security_list_rules.public_subnets.tcp_ingress_ports_from_all`
  * `tcp_ingress_ports_from_vcn` and `udp_ingress_ports_from_vcn` are added to `default_security_list_rules.private_subnets`
  * NAT Gateway and Internet Gateway resource name has changed. Run the following command manually to update the state names
  
  Internet Gateway Resource 
  ```
  terraform state mv module.NETWORK_MODULE_NAME.oci_core_internet_gateway mv module.module.NETWORK_MODULE_NAME.oci_core_internet_gateway\[0\]
  ```
  Nat Gateway Resource 
  ```
  terraform state mv module.NETWORK_MODULE_NAME.oci_core_nat_gateway mv module.module.NETWORK_MODULE_NAME.oci_core_nat_gateway\[0\]
  ```
  Public Route Table Resource 
  ```
  terraform state mv module.NETWORK_MODULE_NAME.oci_core_default_route_table.public_route_table module.NETWORK_MODULE_NAME.oci_core_default_route_table.public_route_table\[\"igw=true\"\]
  ```
  Private Route Table Resource
  ```
  terraform state mv module.NETWORK_MODULE_NAME.oci_core_route_table.private_route_table module.NETWORK_MODULE_NAME.oci_core_route_table.private_route_table\[\"natgw=true:svcgw=false\"\]
  ```
* `instances` modules output is updated:
  * `public_ip` and `private_ip` changed to include vnic info, and primary ip. Also `private_ip` is renamed to `ip_address`:
  ```
  "primary_vnic" = {
      "primary_ip" = {
        "id" = "ocid1.privateip.oc1.xxxxxxxxxxxxxxxx"
        "ip_address" = "xxx.xxx.xxx.xxx"
        "public_ip" = "xxx.xxx.xxx.xxx"
        "subnet_id" = "ocid1.subnet.oc1.xxxxxxxxxxxxxxx"
        "vnic_id" = "ocid1.vnic.oc1.xxxxxxxxxxxxxxx"
      }
      "secondary_ips" = {
        ...
        ...
      }
  }
  ```
* `instances` modules input is updated as following:
  * `config` object has new attribute `primary_vnic`.
    * Add the following when upgrading to fix it.
    ```
    ...
    ...
    config = { 
      primary_vnic = {  <------ this line start
        primary_ip = "", 
        secondary_ips = {}
      } <------ this line end
    }
    ...
    ...
    ```
  * `secondary_vnics` is new attribute to instance object.
    * Add the following to instance object.
    ```
    {
      ...
      ...
      config = {
      ...
      ...
      }
      secondary_vnics = {} <------ this line
      ...
      ...
    }
    ```
* (`kubernetes`) The following new variables are added (Only supported for NextGen Clusters. Do not upgrade to V2 if you are using old clusters). 
  * `k8s_version` is renamed to `cluster_k8s_version`
  * `endpoint_config`: set it to existing configuration (take it from UI)
  * `node_pools[].volume_size_in_gbs`: Set it to `50` to keep current configuration as is.
  * `node_pools[].k8s_version`: Set it to the previous value of `k8s_version` to keep current configuration as is.
  * `node_pools[].flex_shape_config`: Set it to `{}`
  * `node_pools[].node_metadata`: Set it to `{}`
## **New** 
* Add `vault` module to manage KMS (only key management is enabled)
* (`object-storage`) Allow to add `lifecycle-rules` to buckets.
* (`instance`) Ability to add multiple secondary IPs to primary VNIC
* (`instance`) Ability to add multiple secondary VNICs and multiple private IPs
* (`public-ip`) Ability to attach public ip to a given private IP
* (`network`) Ability to 
  * configure `NAT Gateway` (enable/disable, block traffic, assign reserved public IP)
  * configure `Internet Gateway` (enable/disable gateway)
  * Create `Service Gateway`.
* (`kubernetes`) Ability to use `Flex Shape`
* (`kubernetes`) Ability to change node volume size
* (`kubernetes`) Ability to use NextGen Cluster
* (`identity`) Ability to map IdP groups to oci groups.


## **Enhancement**
* (`instances`) Allow rename of instance withour recration (breaking change)
  * You need to add `name` attribute to the instance objects you already created.
* (`network`) Allow display name of subnet to be updated (breaking change)
  * You need to add `name` attribute to the subnet objects you already created.
* (`kuberentes`) Ability to set master node version separately from node pool version.