### PR TITLE
V2.1.0 dev

### DIFF
--- a/modules/common-config/output.tf
+++ b/modules/common-config/output.tf
@@ -20,6 +20,7 @@ output "instance_config" {
       standard-ocp8    = "VM.Standard2.8"
       standard-ocp16   = "VM.Standard2.16"
       standard-ocp24   = "VM.Standard2.24"
+      standard3-flex   = "VM.Standard3.Flex"
       standard-e3-flex = "VM.Standard.E3.Flex"
     }
   }

--- a/modules/instances/README.md
+++ b/modules/instances/README.md
@@ -1,4 +1,5 @@
 - [Instances](#instances)
+  - [Using Flex Shapes](#using-flex-shapes)
 - [Assign Public IP to an instnace](#assign-public-ip-to-an-instnace)
   - [Limitations](#limitations)
   - [Examples](#examples)
@@ -9,6 +10,13 @@ The module iterates over a list of instances as input, and create them. Check `v
 Each object in the input list represent an instance that can have its own configuration, such as which compartment, subnet it belongs to, or which security group is attached to.
 
 Using this module you can attach multiple VNICs to your instance. Moreover, you can assign secondary IP (e.g as floating IP) to each of VNIC.
+
+## Using Flex Shapes
+You have the options to use AMD/Intel flex shapes. Just set `flex_shape_config` key in `var.instances.*.config` varible per instance. The variable `flex_shape_config` should have the following two keys `ocpus` and `memory_in_gbs`. See example below.
+
+Note that, Flex Shape works only with AMD shape `VM.Standard.E3.Flex` and `VM.Standard.E4.Flex`, and Intel `VM.Standard3.Flex`.
+
+Leave `flex_shape_config` empty `{}` if it is not needed.
 
 # Assign Public IP to an instnace
 To attach public IP to any private IP created in this module, you have to do that in `public_ip` module. Refer to `public_ip` module for how to attach private IP to public IP. Using this module output, you can get the private ip OCID and use it in `public_ip` module.
@@ -31,6 +39,10 @@ locals {
       state                    = "RUNNING"
       config = {
         shape    = "ocixxxxxx.xxxxxx.xxxxx"
+        flex_shape_config = {
+          ocpus         = 8
+          memory_in_gbs = 32
+        }
         image_id = "ocixxxxxx.xxxxxx.xxxxx"
         subnet   = { 
           id = "ocixxxxxx.xxxxxx.xxxxx"
@@ -57,6 +69,7 @@ locals {
       state                    = "RUNNING"
       config = {
         shape    = "ocixxxxxx.xxxxxx.xxxxx"
+        flex_shape_config = {}
         image_id = "ocixxxxxx.xxxxxx.xxxxx"
         subnet   = { 
           id = "ocixxxxxx.xxxxxx.xxxxx"

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -49,6 +49,13 @@ resource "oci_core_instance" "instances" {
     ssh_authorized_keys = each.value.autherized_keys
   }
 
+  dynamic "shape_config" {
+    for_each = length(each.value.config.flex_shape_config) == 2 ? [1] : []
+    content {
+      memory_in_gbs = each.value.config.flex_shape_config.memory_in_gbs
+      ocpus         = each.value.config.flex_shape_config.ocpus
+    }
+  }
   create_vnic_details {
     subnet_id                 = each.value.config.subnet.id
     assign_public_ip          = each.value.config.subnet.prohibit_public_ip_on_vnic == false

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -16,9 +16,10 @@ variable "instances" {
     state                    = string
     autherized_keys          = string
     config = object({
-      shape           = string
-      image_id        = string
-      network_sgs_ids = list(string)
+      shape             = string
+      flex_shape_config = map(string)
+      image_id          = string
+      network_sgs_ids   = list(string)
       subnet = object({
         id                         = string,
         prohibit_public_ip_on_vnic = bool
@@ -57,6 +58,7 @@ variable "instances" {
     autherized_keys         : single string containing the SSH-RSA keys seperated by \n
     config                  : object of instance configuration
       shape           : name of the VM shape to be used
+      flex_shape_config     : customize number of ocpus and memory when using Flex Shape
       image_id        : ocid of the boot image
       network_sgs_ids : list network security groups ids to be applied to the main interface
       subnet          : object for the subnet configuration
@@ -80,4 +82,14 @@ variable "instances" {
     optionals : set of key/value map that can be used for customise default values.
       preserve_boot_volume  : whether to keep boot volume after delete or not
   EOF
+
+  validation {
+    condition = alltrue(flatten([
+      for k, v in var.instances : [
+        for key in keys(v.config.flex_shape_config) :
+        contains(["ocpus", "memory_in_gbs"], key)
+      ]
+    ]))
+    error_message = "The instances.*.config.flex_shape_config accepts only \"ocpus\", \"memory_in_gbs\"."
+  }
 }

--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -10,7 +10,7 @@ When the node pool configuration is updated, the existing worker nodes will keep
 ## Using Flex Shapes
 You have the options to use AMD flex shaeps. Just set `flex_shape_config` key in `node_pools` varible per nood pool. The variable `flex_shape_config` should have the following two keys `ocpus` and `memory_in_gbs`. See example below.
 
-Note that, Flex Shape works only with AMD shape `VM.Standard.E3.Flex` and `VM.Standard.E4.Flex`. 
+Note that, Flex Shape works only with AMD shape `VM.Standard.E3.Flex` and `VM.Standard.E4.Flex`, and Intel `VM.Standard3.Flex`.
 
 ## Example
 Creating a cluster with 2 node pools

--- a/releases.md
+++ b/releases.md
@@ -1,3 +1,30 @@
+# v2.1.0:
+_**Please see breaking changes section before upgrading.**_
+## **New**
+* `instances`: add posibility to use flex shape configuration
+
+## _**Breaking Changes**_
+* `instances` modules input is updated. A new key `flex_shape_config` is now required under `var.instances.*.config`.
+  * Add `flex_shape_config` and set its value to `{}`. Example of partial instance object. See module's readme for full example.
+```
+"instance-a" = {
+  name                     = "instance-a"
+  availability_domain_name = "ocixxxxxx.xxxxxx.xxxxx"
+  fault_domain_name        = "ocixxxxxx.xxxxxx.xxxxx"
+  compartment_id           = "ocixxxxxx.xxxxxx.xxxxx"
+  volume_size              = 500
+  autherized_keys          = "ssh-rsa xxxxxxxxxxxxxxxxxxxxxx\n ssh-rsa xxxxxxxxxxxxxxxxxxxxxx"
+  state                    = "RUNNING"
+  config = {
+    shape    = "ocixxxxxx.xxxxxx.xxxxx"
+    flex_shape_config = {}    <-------------------------------------------------------------------- note this line
+    ...
+    ...
+    ...
+    ...
+  }
+}
+```
 # v2.0.1:
 ## Fix
 * `instances`: fix output of module (use `instance.id` instead of `k.id`)


### PR DESCRIPTION
# v2.1.0:
_**Please see breaking changes section before upgrading.**_
## **New**
* `instances`: add posibility to use flex shape configuration

## _**Breaking Changes**_
* `instances` modules input is updated. A new key `flex_shape_config` is now required under `var.instances.*.config`.
  * Add `flex_shape_config` and set its value to `{}`. Example of partial instance object. See module's readme for full example.
```
"instance-a" = {
  name                     = "instance-a"
  availability_domain_name = "ocixxxxxx.xxxxxx.xxxxx"
  fault_domain_name        = "ocixxxxxx.xxxxxx.xxxxx"
  compartment_id           = "ocixxxxxx.xxxxxx.xxxxx"
  volume_size              = 500
  autherized_keys          = "ssh-rsa xxxxxxxxxxxxxxxxxxxxxx\n ssh-rsa xxxxxxxxxxxxxxxxxxxxxx"
  state                    = "RUNNING"
  config = {
    shape    = "ocixxxxxx.xxxxxx.xxxxx"
    flex_shape_config = {}    <-------------------------------------------------------------------- note this line
    ...
    ...
    ...
    ...
  }
}
```