### PR TITLE
V2.1.1 dev

### DIFF
--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -63,7 +63,7 @@ resource "oci_core_instance" "instances" {
     hostname_label            = each.key
     nsg_ids                   = each.value.config.network_sgs_ids
     skip_source_dest_check    = false
-    assign_private_dns_record = false
+    assign_private_dns_record = true
     private_ip                = each.value.config.primary_vnic.primary_ip
   }
 

--- a/modules/instances/output.tf
+++ b/modules/instances/output.tf
@@ -1,7 +1,7 @@
 output "instances" {
   value = {
     for k, instance in oci_core_instance.instances : k => {
-      id           = instance.id
+      id = instance.id
       primary_vnic = {
         primary_ip = [
           for ip in data.oci_core_private_ips.primary_vnic_primary_private_ip[k].private_ips : {

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -4,10 +4,10 @@ resource "oci_containerengine_cluster" "cluster" {
   vcn_id             = var.vcn_id
   kubernetes_version = var.cluster_k8s_version
 
-  endpoint_config {    
+  endpoint_config {
     is_public_ip_enabled = var.endpoint_config.is_public_ip_enabled
-    nsg_ids = var.endpoint_config.nsg_ids
-    subnet_id = var.endpoint_config.subnet_id
+    nsg_ids              = var.endpoint_config.nsg_ids
+    subnet_id            = var.endpoint_config.subnet_id
   }
   options {
     add_ons {

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -29,8 +29,8 @@ variable "lb_subnet_ids" {
 variable "endpoint_config" {
   type = object({
     is_public_ip_enabled = bool
-    nsg_ids = set(string)
-    subnet_id = string
+    nsg_ids              = set(string)
+    subnet_id            = string
   })
 
   description = <<EOF

--- a/releases.md
+++ b/releases.md
@@ -1,3 +1,8 @@
+# v2.1.1:
+## Fix
+* `instances`: fix `assign_private_dns_record` default value. The release in `v2.0.1` broke the functionality. This value has to always be true since we always set the hostname label.
+
+
 # v2.1.0:
 _**Please see breaking changes section before upgrading.**_
 ## **New**


### PR DESCRIPTION
# v2.1.1:
## Fix
* `instances`: fix `assign_private_dns_record` default value. The release in `v2.0.1` broke the functionality. This value has to always be true since we always set the hostname label. #36 