### PR TITLE
Mo: add option to boot from volume

### DIFF
--- a/modules/instances/README.md
+++ b/modules/instances/README.md
@@ -1,6 +1,7 @@
 - [Instances](#instances)
   - [Using Flex Shapes](#using-flex-shapes)
 - [Assign Public IP to an instnace](#assign-public-ip-to-an-instnace)
+- [Booting from an existing Boot Volume](#booting-from-an-existing-boot-volume)
   - [Limitations](#limitations)
   - [Examples](#examples)
   
@@ -20,6 +21,10 @@ Leave `flex_shape_config` empty `{}` if it is not needed.
 
 # Assign Public IP to an instnace
 To attach public IP to any private IP created in this module, you have to do that in `public_ip` module. Refer to `public_ip` module for how to attach private IP to public IP. Using this module output, you can get the private ip OCID and use it in `public_ip` module.
+
+# Booting from an existing Boot Volume 
+It is possible to boot a new instance from an existing boot volume using the `optionals` key in the `instances` map. If not set, a new boot volume will be created from scratch and used. In order to boot from an existing bootVolume set
+`instances[*].optionals.boot_volume_id` and `instances[*].optionals.boot_source_type = "bootVolume`.
 
 ## Limitations
 * Advance Configuration of the instance is not yet possible using this module. The only configuration acceptable are the ones defined in `variables.tf`.
@@ -57,6 +62,10 @@ locals {
         }
       }
       secondary_vnics = {}
+      optionals = {
+        boot_source_type = "bootVolume"
+        boot_volume_id   = "ocid1.bootvolume.oc1.xxxxxxxxxxxxxxxxxxxxxxx"
+      }
     }
     
     "dev-jumpbox" = {
@@ -104,6 +113,7 @@ locals {
           }
         }
       }
+      optionals = {}
     }
 }
 

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -67,10 +67,21 @@ resource "oci_core_instance" "instances" {
     private_ip                = each.value.config.primary_vnic.primary_ip
   }
 
-  source_details {
-    source_type             = "image"
-    source_id               = each.value.config.image_id
-    boot_volume_size_in_gbs = each.value.volume_size
+  dynamic "source_details" {
+    for_each = contains(keys(each.value.optionals), "boot_volume_id") && contains(keys(each.value.optionals), "boot_source_type") ? [1]:[]
+    content {
+      source_type             = lookup(each.value.optionals, "boot_source_type") 
+      source_id               = lookup(each.value.optionals, "boot_volume_id")
+      boot_volume_size_in_gbs = each.value.volume_size
+    }
+  }
+  dynamic "source_details" {
+    for_each = contains(keys(each.value.optionals), "boot_volume_id") && contains(keys(each.value.optionals), "boot_source_type") ? []:[1]
+    content {
+      source_type             = "image"
+      source_id               = each.value.config.image_id
+      boot_volume_size_in_gbs = each.value.volume_size
+    }
   }
 }
 

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -46,6 +46,8 @@ variable "instances" {
     }))
     optionals = map(any)
     # preserve_boot_volume =  bool (true)
+    # boot_volume_id = string
+    # boot_source_type = string
   }))
   description = <<EOF
     map of objects that represent instances to create. The key name is the instance name that is used for FQDN
@@ -81,6 +83,8 @@ variable "instances" {
         ip_address = string
     optionals : set of key/value map that can be used for customise default values.
       preserve_boot_volume  : whether to keep boot volume after delete or not
+      boot_volume_id        : when need to boot from an existing boot volume, set this value to a volume ID
+      boot_source_type      : when need to change boot type: `image` or `bootVolume`
   EOF
 
   validation {

--- a/releases.md
+++ b/releases.md
@@ -1,7 +1,15 @@
+# v2.2.0:
+## **New**
+* `instances`: Add an option to boot a new instance from an existing bootVolume (check doc for `instance` module).
+## _**Breaking Changes**_
+None
+
 # v2.1.1:
 ## Fix
 * `instances`: fix `assign_private_dns_record` default value. The release in `v2.0.1` broke the functionality. This value has to always be true since we always set the hostname label.
 
+## _**Breaking Changes**_
+None
 
 # v2.1.0:
 _**Please see breaking changes section before upgrading.**_


### PR DESCRIPTION
# v2.2.0:
## **New**
* `instances`: Add an option to boot a new instance from an existing bootVolume (check doc for `instance` module).
## _**Breaking Changes**_
None