### PR TITLE
Mo: oke ignore changes to svc lb subnet

### DIFF
--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -25,6 +25,13 @@ resource "oci_containerengine_cluster" "cluster" {
     }
     service_lb_subnet_ids = var.lb_subnet_ids
   }
+
+  lifecycle {
+    ignore_changes = [
+      options[0].service_lb_subnet_ids
+    ]
+    prevent_destroy = true
+  }
 }
 
 resource "oci_containerengine_node_pool" "node_pool" {

--- a/releases.md
+++ b/releases.md
@@ -1,3 +1,13 @@
+# v2.4.1:
+## **New**
+Nonde
+## Fix
+* Ignore changes made to `options[0].service_lb_subnet_ids`, since changing the value can destory the cluster. OKE does not allow updating Service LoadBalncer Subnet anymore, and, it is still there in the API. However, you are not restircted to deploy service load balancer to another subnet using annotations (https://github.com/oracle/oci-cloud-controller-manager/blob/master/docs/load-balancer-annotations.md).
+* add `prevent_destroy` to true, to avoid destorying the cluster due to changes made outside of Terraform.
+
+## _**Breaking Changes**_
+None
+
 # v2.4.0:
 ## **New**
 * `Kubernetes`:


### PR DESCRIPTION
# v2.4.1:
## **New**
Nonde
## Fix
* Ignore changes made to `options[0].service_lb_subnet_ids`, since changing the value can destory the cluster. OKE does not allow updating Service LoadBalncer Subnet anymore, and, it is still there in the API. However, you are not restircted to deploy service load balancer to another subnet using annotations (https://github.com/oracle/oci-cloud-controller-manager/blob/master/docs/load-balancer-annotations.md).
* add `prevent_destroy` to true, to avoid destorying the cluster due to changes made outside of Terraform.

## _**Breaking Changes**_
None