### PR TITLE
V2.5.0 dev

### DIFF
--- a/modules/network/README.md
+++ b/modules/network/README.md
@@ -35,7 +35,8 @@ When the VCN is created, the following objects are created by default:
 
 * Internet Gateway can be disabled via `internet_gateway.enable` variable.
 
-* Servie Gateway is configurable via `service_gateway` variable, and can be disabled as well. When it is created, route rule to "Services ID" is automatically added to `private_route_table`.
+* Servie Gateway is configurable via `service_gateway` variable, and can be disabled as well. When it is created, route rule to "Services ID" is automatically added to `private_route_table` for the default route tabel of the private subnet. To add the route rule to the `public_route_table` for the default route table in public subnet, set the value `var.service_gateway.add_route_rule_in_public_subnet` to `true`.
+
 * All gateways accept an optional parameter that attach a route table. Use one of the variables:
   * `internet_gateway.optionals.route_table_id`
   * `nat_gateway.optionals.route_table_id`
@@ -160,6 +161,7 @@ module "network" {
     enable = true
     service_id = "ocid1.service.oc1.xxxxxxx"
     route_rule_destination = "all-pox-services-in-oracle-services-network"
+    add_route_rule_in_public_subnet = true
     optionals     = {
       route_table_id = "oci.xxxxxxxxx"
     }

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -1,6 +1,6 @@
 // 
 locals {
-  public_route_table_key  = "igw=${var.internet_gateway.enable}"
+  public_route_table_key  = "igw=${var.internet_gateway.enable}:svcgw=${var.service_gateway.enable}"
   private_route_table_key = "natgw=${var.nat_gateway.enable}:svcgw=${var.service_gateway.enable}"
 
   private_route_table = {
@@ -103,7 +103,14 @@ resource "oci_core_default_route_table" "public_route_table" {
       network_entity_id = oci_core_local_peering_gateway.peering_gateway[route_rules.value.name].id
     }
   }
-
+  dynamic "route_rules" {
+    for_each = var.service_gateway.enable == true ? toset([0]) : []
+    content {
+      destination       = var.service_gateway.route_rule_destination
+      destination_type  = "SERVICE_CIDR_BLOCK"
+      network_entity_id = oci_core_service_gateway.service_gateway[0].id
+    }
+  }
   dynamic "route_rules" {
     for_each = var.public_route_table_rules
     content {

--- a/modules/network/main.tf
+++ b/modules/network/main.tf
@@ -104,7 +104,7 @@ resource "oci_core_default_route_table" "public_route_table" {
     }
   }
   dynamic "route_rules" {
-    for_each = var.service_gateway.enable == true ? toset([0]) : []
+    for_each = var.service_gateway.enable == true && var.service_gateway.add_route_rule_in_public_subnet == true ? toset([0]) : []
     content {
       destination       = var.service_gateway.route_rule_destination
       destination_type  = "SERVICE_CIDR_BLOCK"

--- a/modules/network/variables.tf
+++ b/modules/network/variables.tf
@@ -56,17 +56,19 @@ variable "internet_gateway" {
 
 variable "service_gateway" {
   type = object({
-    enable                 = bool
-    service_id             = string
-    route_rule_destination = string
-    optionals              = map(string)
+    enable                          = bool
+    service_id                      = string
+    route_rule_destination          = string
+    add_route_rule_in_public_subnet = bool
+    optionals                       = map(string)
   })
 
   default = {
-    enable                 = false
-    service_id             = ""
-    route_rule_destination = ""
-    optionals              = {}
+    enable                          = false
+    service_id                      = ""
+    route_rule_destination          = ""
+    add_route_rule_in_public_subnet = false
+    optionals                       = {}
   }
 
   description = <<EOF

--- a/releases.md
+++ b/releases.md
@@ -1,11 +1,24 @@
-# v2.4.2:
+# v2.5.0:
 ## **New**
+* `network`: Add route rule to the default public route table when service gateway is enabled (note this is optional to add it to public subnet). Please refer to [known issues with service gateway in public subnet](https://docs.oracle.com/en-us/iaas/Content/Network/Reference/known_issues_for_networking.htm#sgw-route-rule-conflict) before enabling it in public subnet.
+
+## **Fix**
 None
-## Fix
-* Add route rule to the default public route table when service gateway is enabled (note this is optional to add it to public subnet). Please refer to [known issues with service gateway in public subnet](https://docs.oracle.com/en-us/iaas/Content/Network/Reference/known_issues_for_networking.htm#sgw-route-rule-conflict) before enabling it in public subnet.
 
 ## _**Breaking Changes**_
-None
+* `network` modules input is updated. A new key `add_route_rule_in_public_subnet` is now required under `var.service_gateway`.
+  * Add `add_route_rule_in_public_subnet` and set its value to `false`. See module's readme for full example.
+```
+service_gateway = {
+  enable = true
+  service_id = "ocid1.service.oc1.xxxxxxx"
+  route_rule_destination = "all-pox-services-in-oracle-services-network"
+  add_route_rule_in_public_subnet = false <-------------------------------------- note this line
+  optionals     = {
+    route_table_id = "oci.xxxxxxxxx"
+  }
+}
+``` 
 
 # v2.4.1:
 ## **New**

--- a/releases.md
+++ b/releases.md
@@ -1,6 +1,15 @@
+# v2.4.2:
+## **New**
+None
+## Fix
+* Add route rule to the default public route table when service gateway is enabled (note this is optional to add it to public subnet). Please refer to [known issues with service gateway in public subnet](https://docs.oracle.com/en-us/iaas/Content/Network/Reference/known_issues_for_networking.htm#sgw-route-rule-conflict) before enabling it in public subnet.
+
+## _**Breaking Changes**_
+None
+
 # v2.4.1:
 ## **New**
-Nonde
+None
 ## Fix
 * Ignore changes made to `options[0].service_lb_subnet_ids`, since changing the value can destory the cluster. OKE does not allow updating Service LoadBalncer Subnet anymore, and, it is still there in the API. However, you are not restircted to deploy service load balancer to another subnet using annotations (https://github.com/oracle/oci-cloud-controller-manager/blob/master/docs/load-balancer-annotations.md).
 * add `prevent_destroy` to true, to avoid destorying the cluster due to changes made outside of Terraform.


### PR DESCRIPTION
# v2.5.0:
## **New**
* `network`: Add route rule to the default public route table when service gateway is enabled (note this is optional to add it to public subnet). Please refer to [known issues with service gateway in public subnet](https://docs.oracle.com/en-us/iaas/Content/Network/Reference/known_issues_for_networking.htm#sgw-route-rule-conflict) before enabling it in public subnet.

## **Fix**
None

## _**Breaking Changes**_
* `network` modules input is updated. A new key `add_route_rule_in_public_subnet` is now required under `var.service_gateway`.
  * Add `add_route_rule_in_public_subnet` and set its value to `false`. See module's readme for full example.
```
service_gateway = {
  enable = true
  service_id = "ocid1.service.oc1.xxxxxxx"
  route_rule_destination = "all-pox-services-in-oracle-services-network"
  add_route_rule_in_public_subnet = false <-------------------------------------- note this line
  optionals     = {
    route_table_id = "oci.xxxxxxxxx"
  }
}
``` 