### PR TITLE
V2.7.0 dev

### DIFF
--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -161,6 +161,6 @@ resource "oci_core_volume_backup_policy" "boot_volume_backup_policy" {
 resource "oci_core_volume_backup_policy_assignment" "boot_volume_backup_policy_assignment" {
   for_each = { for k, v in var.instances : k => v if lookup(v.optionals, "reference_to_backup_policy_key_name", null) != null }
 
-  asset_id  = oci_core_instance[each.key].boot_volume_id
+  asset_id  = oci_core_instance.instances[each.key].boot_volume_id
   policy_id = oci_core_volume_backup_policy.boot_volume_backup_policy[each.value.reference_to_backup_policy_key_name].id
 }

--- a/modules/instances/output.tf
+++ b/modules/instances/output.tf
@@ -5,11 +5,12 @@ output "instances" {
       primary_vnic = {
         primary_ip = [
           for ip in data.oci_core_private_ips.primary_vnic_primary_private_ip[k].private_ips : {
-            id         = ip.id
-            ip_address = ip.ip_address
-            vnic_id    = ip.vnic_id
-            subnet_id  = ip.subnet_id
-            public_ip  = instance.public_ip
+            id             = ip.id
+            ip_address     = ip.ip_address
+            vnic_id        = ip.vnic_id
+            subnet_id      = ip.subnet_id
+            public_ip      = instance.public_ip
+            hostname_label = ip.hostname_label
           } if ip.is_primary
         ][0]
         secondary_ips = {
@@ -25,17 +26,19 @@ output "instances" {
         vnic.vnic_key => {
           primary_ip = [
             for ip in data.oci_core_private_ips.secondary_vnic_attachment_ips["${vnic.instance_key}:${vnic.vnic_key}"].private_ips : {
-              id         = ip.id
-              ip_address = ip.ip_address
-              vnic_id    = ip.vnic_id
-              subnet_id  = ip.subnet_id
+              id             = ip.id
+              ip_address     = ip.ip_address
+              vnic_id        = ip.vnic_id
+              subnet_id      = ip.subnet_id
+              hostname_label = ip.hostname_label
             } if ip.is_primary
           ][0]
           secondary_ips = {
             for ip in local.flattened_secondary_vnic_secondary_ips :
             ip.secondary_ip_key => {
-              id         = oci_core_private_ip.secondary_vnic_additional_ips["${ip.instance_key}:${ip.vnic_key}:${ip.secondary_ip_key}"].id
-              ip_address = oci_core_private_ip.secondary_vnic_additional_ips["${ip.instance_key}:${ip.vnic_key}:${ip.secondary_ip_key}"].ip_address
+              id             = oci_core_private_ip.secondary_vnic_additional_ips["${ip.instance_key}:${ip.vnic_key}:${ip.secondary_ip_key}"].id
+              ip_address     = oci_core_private_ip.secondary_vnic_additional_ips["${ip.instance_key}:${ip.vnic_key}:${ip.secondary_ip_key}"].ip_address
+              hostname_label = oci_core_private_ip.secondary_vnic_additional_ips["${ip.instance_key}:${ip.vnic_key}:${ip.secondary_ip_key}"].hostname_label
             } if ip.instance_key == k
           }
         } if vnic.instance_key == k

--- a/releases.md
+++ b/releases.md
@@ -1,3 +1,14 @@
+# v2.6.1:
+## **New**
+* `instances`: add `hostname_label` to the output
+
+## **Fix**
+None
+
+## _**Breaking Changes**_
+None
+
+
 # v2.6.0:
 ## **New**
 * `dns`: add ability to manage dns records in oci dns service


### PR DESCRIPTION
# v2.7.0:
## **New**
* `instances`: add `boot_volume_backup_policies` to the input as optional value.
* `instances`: add `instances[*].optional.reference_to_backup_policy_key_name` to the `instance` variable input as optional value to enable scheduled backup of boot volume

## **Fix**
None

## _**Breaking Changes**_
None