### PR TITLE
V2.7.0

### DIFF
--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -162,5 +162,5 @@ resource "oci_core_volume_backup_policy_assignment" "boot_volume_backup_policy_a
   for_each = { for k, v in var.instances : k => v if lookup(v.optionals, "reference_to_backup_policy_key_name", null) != null }
 
   asset_id  = oci_core_instance.instances[each.key].boot_volume_id
-  policy_id = oci_core_volume_backup_policy.boot_volume_backup_policy[each.value.reference_to_backup_policy_key_name].id
+  policy_id = oci_core_volume_backup_policy.boot_volume_backup_policy[each.value.optionals.reference_to_backup_policy_key_name].id
 }

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -133,9 +133,10 @@ variable "instances" {
         name       = string
         ip_address = string
     optionals : set of key/value map that can be used for customise default values.
-      preserve_boot_volume  : whether to keep boot volume after delete or not
-      boot_volume_id        : when need to boot from an existing boot volume, set this value to a volume ID
-      boot_source_type      : when need to change boot type: `image` or `bootVolume`
+      preserve_boot_volume                     : whether to keep boot volume after delete or not
+      boot_volume_id                           : when need to boot from an existing boot volume, set this value to a volume ID
+      boot_source_type                         : when need to change boot type: `image` or `bootVolume`
+      reference_to_backup_policy_key_name      : reference to policy key name in the input `var.boot_volume_backup_policies`. If empty, no backup will be scheduled
   EOF
 
   validation {

--- a/releases.md
+++ b/releases.md
@@ -1,3 +1,14 @@
+# v2.7.0:
+## **New**
+* `instances`: add `boot_volume_backup_policies` to the input as optional value.
+* `instances`: add `instances[*].optional.reference_to_backup_policy_key_name` to the `instance` variable input as optional value to enable scheduled backup of boot volume
+
+## **Fix**
+None
+
+## _**Breaking Changes**_
+None
+
 # v2.6.1:
 ## **New**
 * `instances`: add `hostname_label` to the output


### PR DESCRIPTION
# v2.7.0:
## **New**
* `instances`: add `boot_volume_backup_policies` to the input as optional value.
* `instances`: add `instances[*].optional.reference_to_backup_policy_key_name` to the `instance` variable input as optional value to enable scheduled backup of boot volume

## **Fix**
None

## _**Breaking Changes**_
None
