### PR TITLE
V2.8.0 dev

### DIFF
--- a/modules/instances/README.md
+++ b/modules/instances/README.md
@@ -43,13 +43,15 @@ To create 2 instances:
 locals {
   instances = {
     "prod-jumpbox" = {
-      name                     = "jumpbox-production"
-      availability_domain_name = "ocixxxxxx.xxxxxx.xxxxx"
-      fault_domain_name        = "ocixxxxxx.xxxxxx.xxxxx"
-      compartment_id           = "ocixxxxxx.xxxxxx.xxxxx"
-      volume_size              = 500
-      autherized_keys          = "ssh-rsa xxxxxxxxxxxxxxxxxxxxxx\n ssh-rsa xxxxxxxxxxxxxxxxxxxxxx"
-      state                    = "RUNNING"
+      name                        = "jumpbox-production"
+      availability_domain_name    = "ocixxxxxx.xxxxxx.xxxxx"
+      fault_domain_name           = "ocixxxxxx.xxxxxx.xxxxx"
+      compartment_id              = "ocixxxxxx.xxxxxx.xxxxx"
+      volume_size                 = 500
+      autherized_keys             = "ssh-rsa xxxxxxxxxxxxxxxxxxxxxx\n ssh-rsa xxxxxxxxxxxxxxxxxxxxxx"
+      state                       = "RUNNING"
+      recovery_action             = "RESTORE_INSTANCE"
+      is_live_migration_preferred = true
       config = {
         shape    = "ocixxxxxx.xxxxxx.xxxxx"
         flex_shape_config = {

--- a/modules/instances/README.md
+++ b/modules/instances/README.md
@@ -50,8 +50,6 @@ locals {
       volume_size                 = 500
       autherized_keys             = "ssh-rsa xxxxxxxxxxxxxxxxxxxxxx\n ssh-rsa xxxxxxxxxxxxxxxxxxxxxx"
       state                       = "RUNNING"
-      recovery_action             = "RESTORE_INSTANCE"
-      is_live_migration_preferred = true
       config = {
         shape    = "ocixxxxxx.xxxxxx.xxxxx"
         flex_shape_config = {
@@ -69,6 +67,10 @@ locals {
         primary_vnic = {
           primary_ip = ""
           secondary_ips = {}
+        }
+        availability_config   = { 
+          recovery_action             = "RESTORE_INSTANCE"
+          is_live_migration_preferred = false
         }
       }
       secondary_vnics = {}

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -59,8 +59,8 @@ resource "oci_core_instance" "instances" {
   }
 
   availability_config {
-    is_live_migration_preferred = each.value.is_live_migration_preferred
-    recovery_action             = each.value.recovery_action
+    is_live_migration_preferred = each.value.config.availability_config.is_live_migration_preferred
+    recovery_action             = each.value.config.availability_config.recovery_action
   }
 
   create_vnic_details {

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -57,6 +57,12 @@ resource "oci_core_instance" "instances" {
       ocpus         = each.value.config.flex_shape_config.ocpus
     }
   }
+
+  availability_config {
+    is_live_migration_preferred = each.value.is_live_migration_preferred
+    recovery_action             = each.value.recovery_action
+  }
+
   create_vnic_details {
     subnet_id                 = each.value.config.subnet.id
     assign_public_ip          = each.value.config.subnet.prohibit_public_ip_on_vnic == false

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -56,15 +56,13 @@ variable "boot_volume_backup_policies" {
 
 variable "instances" {
   type = map(object({
-    name                        = string
-    availability_domain_name    = string
-    fault_domain_name           = string
-    compartment_id              = string
-    volume_size                 = number
-    state                       = string
-    autherized_keys             = string
-    recovery_action             = string
-    is_live_migration_preferred = bool
+    name                     = string
+    availability_domain_name = string
+    fault_domain_name        = string
+    compartment_id           = string
+    volume_size              = number
+    state                    = string
+    autherized_keys          = string
     config = object({
       shape             = string
       flex_shape_config = map(string)
@@ -80,6 +78,10 @@ variable "instances" {
           name       = string
           ip_address = string
         }))
+      })
+      availability_config = object({
+        recovery_action             = string,
+        is_live_migration_preferred = bool
       })
     })
     secondary_vnics = map(object({
@@ -124,6 +126,10 @@ variable "instances" {
         secondary_ips : map of objects for secondary IP configuration
           name         : the name of IP
           ip_address   : custom IP that must be in the same subnet above of VNIC. If left empty, oci will create IP dynamically
+      availability_config :  object for VM migration configuration
+        recovery_action : The lifecycle state for an instance when it is recovered after infrastructure maintenance.
+        is_live_migration_preferred : Whether to live migrate supported VM instances to a healthy physical VM host without disrupting.
+
     secondary_vnics: map of object for secondary VNIC configuration
       name       = the name of VNIC
       primary_ip =  custom initial IP. If left empty, oci will create IP dynamically.

--- a/modules/instances/variables.tf
+++ b/modules/instances/variables.tf
@@ -56,13 +56,15 @@ variable "boot_volume_backup_policies" {
 
 variable "instances" {
   type = map(object({
-    name                     = string
-    availability_domain_name = string
-    fault_domain_name        = string
-    compartment_id           = string
-    volume_size              = number
-    state                    = string
-    autherized_keys          = string
+    name                        = string
+    availability_domain_name    = string
+    fault_domain_name           = string
+    compartment_id              = string
+    volume_size                 = number
+    state                       = string
+    autherized_keys             = string
+    recovery_action             = string
+    is_live_migration_preferred = bool
     config = object({
       shape             = string
       flex_shape_config = map(string)

--- a/releases.md
+++ b/releases.md
@@ -1,3 +1,39 @@
+# v2.8.0:
+## **New**
+* `instances`: add new argument availability_config. for VM migration during infrastructure maintenance events
+
+## **Fix**
+None
+
+## _**Breaking Changes**_
+* `instances` modules input is updated. A new key `flex_shape_config` is now required under `var.instances.*.config`.
+  * Add `is_live_migration_preferred` and set its value to `true`. Example of partial instance object. 
+  * Add `recovery_action` and set its value to `RESTORE_INSTANCE`. Example of partial instance object. 
+```
+ instances = {
+    "prod-jumpbox" = {
+      name                        = "jumpbox-production"
+      availability_domain_name    = "ocixxxxxx.xxxxxx.xxxxx"
+      fault_domain_name           = "ocixxxxxx.xxxxxx.xxxxx"
+      compartment_id              = "ocixxxxxx.xxxxxx.xxxxx"
+      volume_size                 = 500
+      autherized_keys             = "ssh-rsa xxxxxxxxxxxxxxxxxxxxxx\n ssh-rsa xxxxxxxxxxxxxxxxxxxxxx"
+      state                       = "RUNNING" 
+      recovery_action             = "RESTORE_INSTANCE"  <--------------------------------------------------- note this line
+      is_live_migration_preferred = true    <--------------------------------------------------- note this line
+    ...
+    ...
+    ...
+    ...
+  }
+}
+```
+
+# v2.5.0:
+## **New**
+* `network`: Add route rule to the default public route table when service gateway is enabled (note this is optional to add it to public subnet). Please refer to [known issues with service gateway in public subnet](https://docs.oracle.com/en-us/iaas/Content/Network/Reference/known_issues_for_networking.htm#sgw-route-rule-conflict) before enabling it in public subnet.
+
+
 # v2.7.1:
 ## **New**
 None

--- a/releases.md
+++ b/releases.md
@@ -1,12 +1,12 @@
 # v2.8.0:
 ## **New**
-* `instances`: add new argument availability_config. for VM migration during infrastructure maintenance events
+* `instances`: add new argument `availability_config`. for VM migration during infrastructure maintenance events
 
 ## **Fix**
 None
 
 ## _**Breaking Changes**_
-* `instances` modules input is updated. A new key `flex_shape_config` is now required under `var.instances.*.config`.
+* `instances` modules input is updated. A new key `availability_config` is now required under `var.instances.*.config`.
   * Add `is_live_migration_preferred` and set its value to `true`. Example of partial instance object. 
   * Add `recovery_action` and set its value to `RESTORE_INSTANCE`. Example of partial instance object. 
 ```

--- a/releases.md
+++ b/releases.md
@@ -29,11 +29,6 @@ None
 }
 ```
 
-# v2.5.0:
-## **New**
-* `network`: Add route rule to the default public route table when service gateway is enabled (note this is optional to add it to public subnet). Please refer to [known issues with service gateway in public subnet](https://docs.oracle.com/en-us/iaas/Content/Network/Reference/known_issues_for_networking.htm#sgw-route-rule-conflict) before enabling it in public subnet.
-
-
 # v2.7.1:
 ## **New**
 None

--- a/releases.md
+++ b/releases.md
@@ -11,22 +11,24 @@ None
   * Add `recovery_action` and set its value to `RESTORE_INSTANCE`. Example of partial instance object. 
 ```
  instances = {
-    "prod-jumpbox" = {
-      name                        = "jumpbox-production"
-      availability_domain_name    = "ocixxxxxx.xxxxxx.xxxxx"
-      fault_domain_name           = "ocixxxxxx.xxxxxx.xxxxx"
-      compartment_id              = "ocixxxxxx.xxxxxx.xxxxx"
-      volume_size                 = 500
-      autherized_keys             = "ssh-rsa xxxxxxxxxxxxxxxxxxxxxx\n ssh-rsa xxxxxxxxxxxxxxxxxxxxxx"
-      state                       = "RUNNING" 
-      recovery_action             = "RESTORE_INSTANCE"  <--------------------------------------------------- note this line
-      is_live_migration_preferred = true    <--------------------------------------------------- note this line
+   ...
+   ...
+   ...
+      network_sgs_ids = [
+          "ocixxxxxx.xxxxxx.xxxxx", "ocixxxxxx.xxxxxx.xxxxx",
+        ]
+        primary_vnic = {
+          primary_ip = ""
+          secondary_ips = {}
+        }
+        availability_config   = {   <--------------------------------------------------- note this block 
+          recovery_action             = "RESTORE_INSTANCE"  
+          is_live_migration_preferred = false
+        }
+      }
+
     ...
     ...
-    ...
-    ...
-  }
-}
 ```
 
 # v2.7.1:


### PR DESCRIPTION
# v2.8.0:
## **New**
* `instances`: add new argument `availability_config`. for VM migration during infrastructure maintenance events

## **Fix**
None

## _**Breaking Changes**_
* `instances` modules input is updated. A new key `availability_config` is now required under `var.instances.*.config`.
  * Add `is_live_migration_preferred` and set its value to `true`. Example of partial instance object. 
  * Add `recovery_action` and set its value to `RESTORE_INSTANCE`. Example of partial instance object. 
```
 instances = {
   ...
   ...
   ...
      network_sgs_ids = [
          "ocixxxxxx.xxxxxx.xxxxx", "ocixxxxxx.xxxxxx.xxxxx",
        ]
        primary_vnic = {
          primary_ip = ""
          secondary_ips = {}
        }
        availability_config   = {   <--------------------------------------------------- note this block 
          recovery_action             = "RESTORE_INSTANCE"  
          is_live_migration_preferred = false
        }
      }
    ...
    ...
```