### PR TITLE
V2.9.0 dev

### DIFF
--- a/modules/identity/README.md
+++ b/modules/identity/README.md
@@ -153,7 +153,20 @@ module "IAM" {
   path = PATH_TO_MODULE
 
   tenant_id = "oci.xxxxxxxxx.xxxxxx"
-  service_accounts = ["terraform-cli", "github-client"] # then using the service accout name, you can assign policy to the service account.
+  service_accounts = {
+    "terraform-cli" = { 
+      name = "terraform-cli", 
+      capabilities = {
+        api_keys = true
+      }
+    }, 
+    "github-client" = {
+      name = "github-client", 
+      capabilities = {
+        smtp_credentials = true
+      }
+    }
+  }
 }
 ```
 
@@ -276,7 +289,20 @@ locals {
     ]
   }
 
-  service_accounts = ["terraform-cicd"]
+  service_accounts = {
+    "terraform-cli" = { 
+      name = "terraform-cli", 
+      capabilities = {
+        api_keys = true
+      }
+    }, 
+    "github-client" = {
+      name = "github-client", 
+      capabilities = {
+        smtp_credentials = true
+      }
+    }
+  }
 
   tenant_id = "oci.xxxxxxxxx.xxxxxx"
 }

--- a/modules/identity/main.tf
+++ b/modules/identity/main.tf
@@ -18,7 +18,7 @@ locals {
   ])
 
   groups                  = [for group in keys(var.memberships) : oci_identity_group.groups[group]]
-  service_accounts_groups = [for sa in var.service_accounts : oci_identity_group.service_accounts_groups[sa]]
+  service_accounts_groups = [for key, sa in var.service_accounts : oci_identity_group.service_accounts_groups[sa.name]]
 
   depends_on = concat(local.groups, local.service_accounts_groups)
 }
@@ -75,27 +75,40 @@ resource "oci_identity_user_group_membership" "user_group_membership" {
 # Service Accounts - to associate a policy with a service account, the
 # service account must belong to a group
 resource "oci_identity_user" "service_accounts" {
-  for_each = toset(var.service_accounts)
+  for_each = var.service_accounts
 
   compartment_id = var.tenant_id
-  description    = each.key
-  name           = each.key
+  description    = each.value.name
+  name           = each.value.name
 }
 
 resource "oci_identity_group" "service_accounts_groups" {
-  for_each = toset(var.service_accounts)
+  for_each = var.service_accounts
 
   compartment_id = var.tenant_id
-  description    = each.key
-  name           = each.key
+  description    = each.value.name
+  name           = each.value.name
 }
 
 resource "oci_identity_user_group_membership" "service_accounts_group_membership" {
-  for_each = toset(var.service_accounts)
+  for_each = var.service_accounts
 
-  group_id = oci_identity_group.service_accounts_groups[each.value].id
-  user_id  = oci_identity_user.service_accounts[each.value].id
+  group_id = oci_identity_group.service_accounts_groups[each.key].id
+  user_id  = oci_identity_user.service_accounts[each.key].id
 }
+
+resource "oci_identity_user_capabilities_management" "service_accounts_capabilities_management" {
+  for_each = var.service_accounts
+
+  user_id = oci_identity_user.service_accounts[each.key].id
+
+  can_use_api_keys             = lookup(each.value.capabilities, "api_keys", false)
+  can_use_auth_tokens          = lookup(each.value.capabilities, "auth_tokens", false)
+  can_use_console_password     = lookup(each.value.capabilities, "console_password", false)
+  can_use_customer_secret_keys = lookup(each.value.capabilities, "customer_secret_keys", false)
+  can_use_smtp_credentials     = lookup(each.value.capabilities, "smtp_credentials", false)
+}
+
 
 # Some policies have to be applied at the tenancy level so compartment_id must be the tenant_id
 resource "oci_identity_policy" "tenancy_policies" {

--- a/modules/identity/variables.tf
+++ b/modules/identity/variables.tf
@@ -51,15 +51,33 @@ variable "memberships" {
   EOF
 }
 
+# Note this will completely changed in V3 of this module
 variable "service_accounts" {
-  type        = set(string)
-  default     = []
+  type    = map(object({ name = string, capabilities = map(bool) }))
+  default = {}
+
+  validation {
+    condition = alltrue(flatten([
+      for key, service_account in var.service_accounts : [
+        for capability in keys(service_account.capabilities) : contains(["api_keys", "auth_tokens", "console_password", "customer_secret_keys", "smtp_credentials"], capability)
+      ]
+    ]))
+    error_message = "The var.service_accounts.*.capabilities accepts \"api_keys\", \"auth_tokens\", \"console_password\", \"customer_secret_keys\", \"smtp_credentials\"."
+  }
+
   description = <<EOF
     This variable is optonal.
-    Set of service account users. A group with the same name of the service account
+    map of service account names. A group with the same name of the service account
     will be created and the service account will be added to it. This is because
     policy can only be applied to group. This way you can attach policy to the service
     account by using its name as group name.
+      name: name of the service account and its group
+      capabilities: map of bool to set service_account capabilities. Allowed values:
+        api_keys
+        auth_tokens
+        console_password
+        customer_secret_keys
+        smtp_credentials
   EOF
 }
 

--- a/releases.md
+++ b/releases.md
@@ -1,3 +1,37 @@
+# v2.9.0:
+## **New**
+* `identity`: add new argument `capabilities` in `var.service_accounts` variable.
+
+## **Fix**
+None
+## _**Breaking Changes**_
+* `identity` modules input for `service_accounts` is updated. A new key `capabilities` is now required under `var.service_accounts.*`.
+  * Add `capabilities` and set its value to `{}`.
+
+from:
+>```h
+>module "identity" {
+>  ...
+>  service_accounts = toset(["terraform-cli"])
+>  ...
+>}
+>```
+to:
+>```h
+>module "identity" {
+>  ...
+>  service_accounts = {
+>    "terraform-cli" = { 
+>      name = "terraform-cli", 
+>      capabilities = {}
+>    }
+>  }
+>  ...
+>}
+```
+
+
+
 # v2.8.0:
 ## **New**
 * `instances`: add new argument `availability_config`. for VM migration during infrastructure maintenance events


### PR DESCRIPTION
# v2.9.0:
## **New**
* `identity`: add new argument `capabilities` in `var.service_accounts` variable.

## **Fix**
* Correct `path` argument by `source` argument to specify the module path in `identity` module usage examples in `README.md`.

## _**Breaking Changes**_
* `identity` modules input for `service_accounts` is updated. A new key `capabilities` is now required under `var.service_accounts.*`.
  * Add `capabilities` and set its value to `{}`.

from:
>```h
>module "identity" {
>  ...
>  service_accounts = toset(["terraform-cli"])
>  ...
>}
>```
to:
>```h
>module "identity" {
>  ...
>  service_accounts = {
>    "terraform-cli" = { 
>      name = "terraform-cli", 
>      capabilities = {}
>    }
>  }
>  ...
>}
```