### PR TITLE
V2.10.0 dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,4 @@ Thanks to the following folks for providing suggestions and improvments to this 
 * Grzegorz M [grzesjam](https://github.com/grzesjam) (v1.0 public-ip module)
 * Mateusz Kozakiewicz [mateuszkozakiewicz](https://github.com/mateuszkozakiewicz) (v1.0 public-ip module)
 * Abdullah Bin Rasheed [Twirlyz](https://github.com/Twirlyz) (dns module)
+* Remaz Altuwaim [remaz2250](https://github.com/remaz2250) (v2.8.0 and v2.10.0 instance/network-sg module)

--- a/modules/network-sg/README.md
+++ b/modules/network-sg/README.md
@@ -12,7 +12,6 @@ Using this module you can configure an NSG and customise rules for each group. H
 * IP Protocols are limited only to TCP and UDP
 * Destination or Source are limited to type `CIDR_BLOCK` (IP address only)
 * All rules are stateful.
-* Port range for rules is not supported (Each rule covers a single port, so you have to create multiple rules for each port)
 * No support for setting the source port (Port is limited to destination of packet)
 
 ## Rules and IPs
@@ -26,7 +25,7 @@ Creating two security groups with the following rules:
 * Group 1:
   * Rule 1: allow TCP ingress to IPs ["192.168.100.12", "192.168.100.12"] to port 9090
   * Rule 2: allow TCP ingress to IPs ["192.168.100.14", "192.168.100.16"] to port 9091
-  * Rule 3: allow TCP egress from IPs ["192.168.100.12", "192.168.100.12"] to port 8000
+  * Rule 3: allow TCP egress from IPs ["192.168.100.12", "192.168.100.12"] to port range 8000-8002
 * Group 2:
   * Rule 1: allow UDP ingress from IPs ["192.168.200.12", "192.168.200.13"] to port 30091
   * Rule 2: allow TCP ingress from IPs ["192.168.200.12", "192.168.100.12"] to port 9000
@@ -42,19 +41,19 @@ module "network_secuirty_groups" {
       "rule_1" = {
         direction = "INGRESS"
         protocol  = "tcp"
-        port      = 9090
+        port      = { min : 9090, max : 9090 }
         ips       = ["192.168.100.12", "192.168.100.12"]
       }
       "rule_2" = {
         direction = "INGRESS"
         protocol  = "tcp"
-        port      = 9091
+        port      = { min : 9091, max : 9091 }
         ips       = ["192.168.100.14", "192.168.100.16"]
       }
       "rule_1" = {
         direction = "EGRESS"
         protocol  = "tcp"
-        port      = 8000
+        port      = { min : 8000, max : 8002 }
         ips       = ["192.168.100.12", "192.168.100.12"]
       }
     }
@@ -63,13 +62,13 @@ module "network_secuirty_groups" {
       "rule_1" = {
         direction = "INGRESS"
         protocol  = "udp"
-        port      = 30091
+        port      = { min : 30091, max : 30091 }
         ips       = ["192.168.200.12", "192.168.200.13"]
       }
       "rule_2" = {
         direction = "INGRESS"
         protocol  = "tcp"
-        port      = 9000
+        port      = { min : 9000, max : 9000 }
         ips       = ["192.168.200.12", "192.168.100.12"]
       }
     }

--- a/modules/network-sg/main.tf
+++ b/modules/network-sg/main.tf
@@ -23,7 +23,7 @@ locals {
           rulename  = rulename
           direction = rule.direction
           protocol  = rule.protocol
-          port      = rule.port
+          ports     = rule.ports
           ip        = ip
         }
       ]
@@ -43,7 +43,7 @@ resource "oci_core_network_security_group" "security_group" {
 // Create INGRESS rules
 resource "oci_core_network_security_group_security_rule" "ingress_rule" {
   for_each = { for rule in local.flatten_rules :
-    "${rule.group}:${rule.rulename}:${rule.direction}:${rule.ip}:${rule.port}" => rule
+    "${rule.group}:${rule.rulename}:${rule.direction}:${rule.ip}:${rule.ports.min}:${rule.ports.max}" => rule
   if rule.direction == "INGRESS" }
 
   network_security_group_id = oci_core_network_security_group.security_group[each.value.group].id
@@ -55,21 +55,21 @@ resource "oci_core_network_security_group_security_rule" "ingress_rule" {
   source_type               = "CIDR_BLOCK"
 
   dynamic "tcp_options" {
-    for_each = each.value.protocol == "tcp" ? [each.value.port] : []
+    for_each = each.value.protocol == "tcp" ? [each.value.ports] : []
     content {
       destination_port_range {
-        max = tcp_options.value
-        min = tcp_options.value
+        max = tcp_options.value.max
+        min = tcp_options.value.min
       }
     }
   }
 
   dynamic "udp_options" {
-    for_each = each.value.protocol == "udp" ? [each.value.port] : []
+    for_each = each.value.protocol == "udp" ? [each.value.ports] : []
     content {
       destination_port_range {
-        max = udp_options.value
-        min = udp_options.value
+        max = udp_options.value.max
+        min = udp_options.value.min
       }
     }
   }
@@ -78,7 +78,7 @@ resource "oci_core_network_security_group_security_rule" "ingress_rule" {
 // Create EGRESS rules
 resource "oci_core_network_security_group_security_rule" "egress_rule" {
   for_each = { for rule in local.flatten_rules :
-    "${rule.group}:${rule.rulename}:${rule.direction}:${rule.ip}:${rule.port}" => rule
+    "${rule.group}:${rule.rulename}:${rule.direction}:${rule.ip}:${rule.ports.min}:${rule.ports.max}" => rule
   if rule.direction == "EGRESS" }
 
   network_security_group_id = oci_core_network_security_group.security_group[each.value.group].id
@@ -90,21 +90,21 @@ resource "oci_core_network_security_group_security_rule" "egress_rule" {
   destination_type          = "CIDR_BLOCK"
 
   dynamic "tcp_options" {
-    for_each = each.value.protocol == "tcp" ? [each.value.port] : []
+    for_each = each.value.protocol == "tcp" ? [each.value.ports] : []
     content {
       destination_port_range {
-        max = tcp_options.value
-        min = tcp_options.value
+        max = tcp_options.value.max
+        min = tcp_options.value.min
       }
     }
   }
 
   dynamic "udp_options" {
-    for_each = each.value.protocol == "udp" ? [each.value.port] : []
+    for_each = each.value.protocol == "udp" ? [each.value.ports] : []
     content {
       destination_port_range {
-        max = udp_options.value
-        min = udp_options.value
+        max = udp_options.value.max
+        min = udp_options.value.min
       }
     }
   }

--- a/modules/network-sg/main.tf
+++ b/modules/network-sg/main.tf
@@ -11,9 +11,9 @@ locals {
   // map the network_security_groups into an array of all rules flattened
   /*
   from:
-    {"group-1" = {"rule-1" = { ips = [1, 2], port=22, ...}}, ....}
+    {"group-1" = {"rule-1" = { ips = [1, 2], ports = {min: 22, max: 22}, ...}}, ....}
   To:
-    [{group = "group-1", rulename= "rule-1", port = 22, ip = 1}, {group = "group-1", rulename= "rule-1", port = 22, ip = 2} ]
+    [{group = "group-1", rulename= "rule-1", ports = {min: 22, max: 22}, ip = 1}, {group = "group-1", rulename= "rule-1", ports = {min: 22, max: 22}, ip = 2} ]
   */
   flatten_rules = flatten([
     for group, rules in var.network_security_groups : [

--- a/releases.md
+++ b/releases.md
@@ -1,3 +1,28 @@
+# v2.10.0:
+## **New**
+* `network-sg`: change input type to support ports range in `var.network_security_groups.*.ports` variable.
+
+## **Fix**
+None
+
+## _**Breaking Changes**_
+* `network-sg` modules input for `network_security_groups` is updated. The subkey `port` is replaced with `ports` and it is now a map of two objects `max` and `min`. 
+
+```h
+network_security_groups = {
+    "group_1" = {
+      "rule_1" = {
+        direction = "INGRESS"
+        protocol  = "tcp"
+        port      = { min : 9090, max : 9090 }
+        ips       = ["192.168.100.12", "192.168.100.12"]
+      }
+    }
+}
+```
+* Currently there is no easy migration path for this change, since the terraform resource name is updated. However, destroying and recreating the rules is the best and fastest way to do it, however, it might impact your networks for few minutes. Alternatively, reference the new release in a new module definition, and migration your rules one by one.
+
+
 # v2.9.0:
 ## **New**
 * `identity`: add new argument `capabilities` in `var.service_accounts` variable.


### PR DESCRIPTION
# v2.10.0:
## **New**
* `network-sg`: change input type to support ports range in `var.network_security_groups.*.ports` variable.

## **Fix**
None

## _**Breaking Changes**_
* `network-sg` modules input for `network_security_groups` is updated. The subkey `port` is replaced with `ports` and it is now a map of two objects `max` and `min`. 

```h
network_security_groups = {
    "group_1" = {
      "rule_1" = {
        direction = "INGRESS"
        protocol  = "tcp"
        port      = { min : 9090, max : 9090 }
        ips       = ["192.168.100.12", "192.168.100.12"]
      }
    }
}
```
* Currently there is no easy migration path for this change, since the terraform resource name is updated. However, destroying and recreating the rules is the best and fastest way to do it, however, it might impact your networks for few minutes. Alternatively, reference the new release in a new module definition, and migration your rules one by one.