### PR TITLE
remaz: Ignore user_data changes in instances

### DIFF
--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -63,6 +63,12 @@ resource "oci_core_instance" "instances" {
     recovery_action             = each.value.config.availability_config.recovery_action
   }
 
+  lifecycle {
+    ignore_changes = [
+      metadata.user_data
+    ]
+  }
+
   create_vnic_details {
     subnet_id                 = each.value.config.subnet.id
     assign_public_ip          = each.value.config.subnet.prohibit_public_ip_on_vnic == false

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -65,7 +65,7 @@ resource "oci_core_instance" "instances" {
 
   lifecycle {
     ignore_changes = [
-      metadata.user_data
+      metadata["user_data"]
     ]
   }
 

--- a/releases.md
+++ b/releases.md
@@ -14,7 +14,7 @@ resource "oci_core_instance" "instances" {
   }
   lifecycle {
     ignore_changes = [
-      metadata.user_data    <------------------------------ note this 
+      metadata["user_data"]   <------------------------------ note this 
     ]
   }
 }

--- a/releases.md
+++ b/releases.md
@@ -1,3 +1,29 @@
+# v2.10.1:
+## **New**
+None
+
+## **Fix**
+* Ignore changes made to `metadata.user_data` in any instance, since changing the value will destroy and recreate the instance. 
+```h
+resource "oci_core_instance" "instances" {
+  ...
+  ...
+  metadata = {
+    ssh_authorized_keys = each.value.autherized_keys
+    user_data           = lookup(each.value.optionals, "user_data", null)
+  }
+  lifecycle {
+    ignore_changes = [
+      metadata.user_data    <------------------------------ note this 
+    ]
+  }
+}
+```
+
+## _**Breaking Changes**_
+None
+
+
 # v2.10.0:
 ## **New**
 * `network-sg`: change input type to support ports range in `var.network_security_groups.*.ports` variable.
@@ -35,25 +61,25 @@ network_security_groups = {
   * Add `capabilities` and set its value to `{}`.
 
 from:
->```h
->module "identity" {
->  ...
->  service_accounts = toset(["terraform-cli"])
->  ...
->}
->```
+```h
+module "identity" {
+  ...
+  service_accounts = toset(["terraform-cli"])
+  ...
+}
+```
 to:
->```h
->module "identity" {
->  ...
->  service_accounts = {
->    "terraform-cli" = { 
->      name = "terraform-cli", 
->      capabilities = {}
->    }
->  }
->  ...
->}
+```h
+module "identity" {
+  ...
+  service_accounts = {
+    "terraform-cli" = { 
+      name = "terraform-cli", 
+      capabilities = {}
+    }
+  }
+  ...
+}
 ```
 
 # v2.8.0:


### PR DESCRIPTION
# v2.10.1:
## **New**
None

## **Fix**
* Ignore changes made to `metadata.user_data` in any instance, since changing the value will destroy and recreate the instance. 
```h
resource "oci_core_instance" "instances" {
  ...
  ...
  metadata = {
    ssh_authorized_keys = each.value.autherized_keys
    user_data           = lookup(each.value.optionals, "user_data", null)
  }
  lifecycle {
    ignore_changes = [
      metadata["user_data"]   <------------------------------ note this 
    ]
  }
}
```

## _**Breaking Changes**_
None