### PR TITLE
v2.10.1-dev

### DIFF
--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -63,6 +63,12 @@ resource "oci_core_instance" "instances" {
     recovery_action             = each.value.config.availability_config.recovery_action
   }
 
+  lifecycle {
+    ignore_changes = [
+      metadata.user_data
+    ]
+  }
+
   create_vnic_details {
     subnet_id                 = each.value.config.subnet.id
     assign_public_ip          = each.value.config.subnet.prohibit_public_ip_on_vnic == false

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -65,7 +65,7 @@ resource "oci_core_instance" "instances" {
 
   lifecycle {
     ignore_changes = [
-      metadata.user_data
+      metadata["user_data"]
     ]
   }
 

--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -42,6 +42,7 @@ module "kubernetes" {
       node_metadata         = {}
       volume_size_in_gbs    = 500
       size                  = 2
+      defined_tags          = { "Oracle-Tags.CreatedBy" = "oke"}
       k8s_version           = "v1.18.10"
       image_id              = "ocixxxxxx.xxxxxx.xxxxx"
       labels = {
@@ -58,6 +59,7 @@ module "kubernetes" {
       node_metadata       = {}                
       volume_size_in_gbs  = 50
       size                = 4
+      defined_tags          = { "Oracle-Tags.CreatedBy" = "oke"}
       k8s_version         = "v1.18.10"
       image_id            = "ocixxxxxx.xxxxxx.xxxxx"
       flex_shape_config = {
@@ -77,6 +79,7 @@ module "kubernetes" {
       node_metadata       = {}                
       volume_size_in_gbs  = 50
       size                = 0   # this will force terraform to ignore changes to the pool size when autoscale kicks in
+      defined_tags          = { "Oracle-Tags.CreatedBy" = "oke"}
       k8s_version         = "v1.18.10"
       image_id            = "ocixxxxxx.xxxxxx.xxxxx"
       flex_shape_config = {

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -53,7 +53,8 @@ resource "oci_containerengine_node_pool" "node_pool" {
     }
   }
   node_config_details {
-    size = each.value.size
+    size         = each.value.size
+    defined_tags = each.value.defined_tags
     placement_configs {
       availability_domain = each.value.availability_domain
       subnet_id           = each.value.subnet_id
@@ -94,7 +95,8 @@ resource "oci_containerengine_node_pool" "node_pool_ignored_size" {
     }
   }
   node_config_details {
-    size = each.value.size
+    size         = each.value.size
+    defined_tags = each.value.defined_tags
     placement_configs {
       availability_domain = each.value.availability_domain
       subnet_id           = each.value.subnet_id

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -51,6 +51,7 @@ variable "node_pools" {
     volume_size_in_gbs  = number
     image_id            = string
     labels              = map(string)
+    defined_tags        = map(string)
     subnet_id           = string
     k8s_version         = string
     flex_shape_config   = map(string)
@@ -67,6 +68,7 @@ variable "node_pools" {
     volume_size_in_gbs : Size of Boot volume in GB per node
     image_id           : ocid of the image
     labels             : map of key/string values to be added to the node during creation
+    defined_tags       : Defined tags for this resource. Each key is predefined and scoped to a namespace.
     subnet_id          : ocid of the subnet to create the node in.
     k8s_version        : set the version of the node pool
     flex_shape_config  : customize number of ocpus and memory when using Flex Shape

--- a/modules/network-sg/README.md
+++ b/modules/network-sg/README.md
@@ -10,7 +10,6 @@ Using this module you can configure an NSG and customise rules for each group. H
 
 ## Limitations
 * IP Protocols are limited only to TCP and UDP
-* Destination or Source are limited to type `CIDR_BLOCK` (IP address only)
 * All rules are stateful.
 * No support for setting the source port (Port is limited to destination of packet)
 

--- a/modules/network-sg/main.tf
+++ b/modules/network-sg/main.tf
@@ -52,7 +52,7 @@ resource "oci_core_network_security_group_security_rule" "ingress_rule" {
   description               = each.value.rulename
   stateless                 = false
   source                    = each.value.ip
-  source_type               = "CIDR_BLOCK"
+  source_type               = lookup(each.value, "source_type", "CIDR_BLOCK")
 
   dynamic "tcp_options" {
     for_each = each.value.protocol == "tcp" ? [each.value.ports] : []
@@ -87,7 +87,7 @@ resource "oci_core_network_security_group_security_rule" "egress_rule" {
   description               = each.value.rulename
   stateless                 = false
   destination               = each.value.ip
-  destination_type          = "CIDR_BLOCK"
+  destination_type          = lookup(each.value, "destination_type", "CIDR_BLOCK")
 
   dynamic "tcp_options" {
     for_each = each.value.protocol == "tcp" ? [each.value.ports] : []

--- a/modules/network-sg/variables.tf
+++ b/modules/network-sg/variables.tf
@@ -14,6 +14,8 @@ variable "network_security_groups" {
     protocol  = string
     ports     = object({ min : number, max : number })
     ips       = set(string)
+    source_type      = optional(string, "CIDR_BLOCK") # Optional, default to CIDR_BLOCK
+    destination_type = optional(string, "CIDR_BLOCK") # Optional, default to CIDR_BLOCK
   })))
 
   default = {}
@@ -39,5 +41,7 @@ variable "network_security_groups" {
         min: lower port bound 
         max: upper port bound
     ips      : list of IP addresses for the rule
+    source_type: optional; defaults to "CIDR_BLOCK" for INGRESS rules
+    destination_type: optional; defaults to "CIDR_BLOCK" for EGRESS rules
   EOL
 }

--- a/releases.md
+++ b/releases.md
@@ -14,7 +14,7 @@ resource "oci_core_instance" "instances" {
   }
   lifecycle {
     ignore_changes = [
-      metadata.user_data    <------------------------------ note this 
+      metadata["user_data"]   <------------------------------ note this 
     ]
   }
 }

--- a/releases.md
+++ b/releases.md
@@ -1,3 +1,29 @@
+# v2.10.1:
+## **New**
+None
+
+## **Fix**
+* Ignore changes made to `metadata.user_data` in any instance, since changing the value will destroy and recreate the instance. 
+```h
+resource "oci_core_instance" "instances" {
+  ...
+  ...
+  metadata = {
+    ssh_authorized_keys = each.value.autherized_keys
+    user_data           = lookup(each.value.optionals, "user_data", null)
+  }
+  lifecycle {
+    ignore_changes = [
+      metadata.user_data    <------------------------------ note this 
+    ]
+  }
+}
+```
+
+## _**Breaking Changes**_
+None
+
+
 # v2.10.0:
 ## **New**
 * `network-sg`: change input type to support ports range in `var.network_security_groups.*.ports` variable.
@@ -35,25 +61,25 @@ network_security_groups = {
   * Add `capabilities` and set its value to `{}`.
 
 from:
->```h
->module "identity" {
->  ...
->  service_accounts = toset(["terraform-cli"])
->  ...
->}
->```
+```h
+module "identity" {
+  ...
+  service_accounts = toset(["terraform-cli"])
+  ...
+}
+```
 to:
->```h
->module "identity" {
->  ...
->  service_accounts = {
->    "terraform-cli" = { 
->      name = "terraform-cli", 
->      capabilities = {}
->    }
->  }
->  ...
->}
+```h
+module "identity" {
+  ...
+  service_accounts = {
+    "terraform-cli" = { 
+      name = "terraform-cli", 
+      capabilities = {}
+    }
+  }
+  ...
+}
 ```
 
 # v2.8.0:

--- a/releases.md
+++ b/releases.md
@@ -1,6 +1,8 @@
 # v2.10.1:
 ## **New**
-None
+* Update the nsg variables to include `source_type` and `destination_type` in the rule configurations.
+* Update the module's variable definition to handle optional `source_type` and `destination_type`.
+* Modify resource definitions to use these new attributes and provide defaults if they are not specified.
 
 ## **Fix**
 * Ignore changes made to `metadata.user_data` in any instance, since changing the value will destroy and recreate the instance. 


### PR DESCRIPTION
# v2.10.1:
## **New**
None

## **Fix**
* Ignore changes made to `metadata.user_data` in any instance, since changing the value will destroy and recreate the instance. 
```h
resource "oci_core_instance" "instances" {
  ...
  ...
  metadata = {
    ssh_authorized_keys = each.value.autherized_keys
    user_data           = lookup(each.value.optionals, "user_data", null)
  }
  lifecycle {
    ignore_changes = [
      metadata["user_data"]   <------------------------------ note this 
    ]
  }
}
```

## _**Breaking Changes**_
None