### PR TITLE
v2.10.1-dev - Add Support of Defined Tags for OKE Nodes

### DIFF
--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -42,6 +42,7 @@ module "kubernetes" {
       node_metadata         = {}
       volume_size_in_gbs    = 500
       size                  = 2
+      defined_tags          = { "Oracle-Tags.CreatedBy" = "oke"}
       k8s_version           = "v1.18.10"
       image_id              = "ocixxxxxx.xxxxxx.xxxxx"
       labels = {
@@ -58,6 +59,7 @@ module "kubernetes" {
       node_metadata       = {}                
       volume_size_in_gbs  = 50
       size                = 4
+      defined_tags          = { "Oracle-Tags.CreatedBy" = "oke"}
       k8s_version         = "v1.18.10"
       image_id            = "ocixxxxxx.xxxxxx.xxxxx"
       flex_shape_config = {
@@ -77,6 +79,7 @@ module "kubernetes" {
       node_metadata       = {}                
       volume_size_in_gbs  = 50
       size                = 0   # this will force terraform to ignore changes to the pool size when autoscale kicks in
+      defined_tags          = { "Oracle-Tags.CreatedBy" = "oke"}
       k8s_version         = "v1.18.10"
       image_id            = "ocixxxxxx.xxxxxx.xxxxx"
       flex_shape_config = {

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -54,7 +54,7 @@ resource "oci_containerengine_node_pool" "node_pool" {
   }
   node_config_details {
     size         = each.value.size
-    defined_tags = each.value.defined_tags ? each.value.defined_tags : { "tag.Oracle-Tags.CreatedBy.value" = "oke" }
+    defined_tags = lookup(each.value.defined_tags, "defined_tags", { "tag.Oracle-Tags.CreatedBy.value" = "oke" })
     placement_configs {
       availability_domain = each.value.availability_domain
       subnet_id           = each.value.subnet_id
@@ -95,8 +95,8 @@ resource "oci_containerengine_node_pool" "node_pool_ignored_size" {
     }
   }
   node_config_details {
-    size = each.value.size
-    defined_tags = each.value.defined_tags ? each.value.defined_tags : { "tag.Oracle-Tags.CreatedBy.value" = "oke" }
+    size         = each.value.size
+    defined_tags = lookup(each.value.defined_tags, "defined_tags", { "tag.Oracle-Tags.CreatedBy.value" = "oke" })
     placement_configs {
       availability_domain = each.value.availability_domain
       subnet_id           = each.value.subnet_id

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -96,6 +96,7 @@ resource "oci_containerengine_node_pool" "node_pool_ignored_size" {
   }
   node_config_details {
     size = each.value.size
+    defined_tags = each.value.defined_tags ? each.value.defined_tags : { "tag.Oracle-Tags.CreatedBy.value" = "oke" }
     placement_configs {
       availability_domain = each.value.availability_domain
       subnet_id           = each.value.subnet_id

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -54,7 +54,7 @@ resource "oci_containerengine_node_pool" "node_pool" {
   }
   node_config_details {
     size         = each.value.size
-    defined_tags = lookup(each.value.defined_tags, "defined_tags", { "tag.Oracle-Tags.CreatedBy.value" = "oke" })
+    defined_tags = each.value.defined_tags
     placement_configs {
       availability_domain = each.value.availability_domain
       subnet_id           = each.value.subnet_id
@@ -96,7 +96,7 @@ resource "oci_containerengine_node_pool" "node_pool_ignored_size" {
   }
   node_config_details {
     size         = each.value.size
-    defined_tags = lookup(each.value.defined_tags, "defined_tags", { "tag.Oracle-Tags.CreatedBy.value" = "oke" })
+    defined_tags = each.value.defined_tags
     placement_configs {
       availability_domain = each.value.availability_domain
       subnet_id           = each.value.subnet_id

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -53,7 +53,8 @@ resource "oci_containerengine_node_pool" "node_pool" {
     }
   }
   node_config_details {
-    size = each.value.size
+    size         = each.value.size
+    defined_tags = each.value.defined_tags ? each.value.defined_tags : { "tag.Oracle-Tags.CreatedBy.value" = "oke" }
     placement_configs {
       availability_domain = each.value.availability_domain
       subnet_id           = each.value.subnet_id

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -51,6 +51,7 @@ variable "node_pools" {
     volume_size_in_gbs  = number
     image_id            = string
     labels              = map(string)
+    defined_tags        = map(string)
     subnet_id           = string
     k8s_version         = string
     flex_shape_config   = map(string)
@@ -67,6 +68,7 @@ variable "node_pools" {
     volume_size_in_gbs : Size of Boot volume in GB per node
     image_id           : ocid of the image
     labels             : map of key/string values to be added to the node during creation
+    defined_tags       : Defined tags for this resource. Each key is predefined and scoped to a namespace.
     subnet_id          : ocid of the subnet to create the node in.
     k8s_version        : set the version of the node pool
     flex_shape_config  : customize number of ocpus and memory when using Flex Shape


### PR DESCRIPTION
This will allow the OKE nodes to utilize the Defined Tags on OCI, a such case would be allowing the OKE nodes to access OCI resources based on the Defined Tags.