### PR TITLE
V2.10.1 dev: Make defined_tags as optional parameter

### DIFF
--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -51,7 +51,7 @@ variable "node_pools" {
     volume_size_in_gbs  = number
     image_id            = string
     labels              = map(string)
-    defined_tags        = map(string)
+    defined_tags        = optional(map(string))
     subnet_id           = string
     k8s_version         = string
     flex_shape_config   = map(string)

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -51,7 +51,7 @@ variable "node_pools" {
     volume_size_in_gbs  = number
     image_id            = string
     labels              = map(string)
-    defined_tags        = map(string) # optional(map(string))
+    defined_tags        = optional(map(string))
     subnet_id           = string
     k8s_version         = string
     flex_shape_config   = map(string)

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -51,7 +51,7 @@ variable "node_pools" {
     volume_size_in_gbs  = number
     image_id            = string
     labels              = map(string)
-    defined_tags        = optional(map(string))
+    defined_tags        = map(string) # optional(map(string))
     subnet_id           = string
     k8s_version         = string
     flex_shape_config   = map(string)


### PR DESCRIPTION
So, what we need is to make this `defined_tags` parameter as optional as it's not a required variable according to the [Terrafrom official resource](https://registry.terraform.io/providers/oracle/oci/latest/docs/resources/containerengine_node_pool#defined_tags).
