### PR TITLE
BT: support object storage module with replication

### DIFF
--- a/modules/object-storage/README.md
+++ b/modules/object-storage/README.md
@@ -37,6 +37,11 @@ module "buckets" {
           inclusion_prefixes = []
         }
       }
+      replication_policy = {
+        name                    = "replicate_my_website_images_to_riyadh"
+        destination_region      = "me-riyadh-1"
+        destination_bucket_name = "my-website-images"                 
+      }
       optionals      = {
         object_events_enabled = false 
         versioning_enabled = true

--- a/modules/object-storage/main.tf
+++ b/modules/object-storage/main.tf
@@ -46,3 +46,14 @@ resource "oci_objectstorage_object_lifecycle_policy" "lifecycle_policy" {
     }
   }
 }
+
+resource "oci_objectstorage_replication_policy" "bucket_replication" {
+  for_each = {
+    for k, v in var.buckets : k => v.replication_policy if v.replication_policy != null
+  }
+  bucket                  = oci_objectstorage_bucket.bucket[each.key].name
+  namespace               = data.oci_objectstorage_namespace.namespace.namespace
+  destination_bucket_name = lookup(each.value, "destination_bucket_name", oci_objectstorage_bucket.bucket[each.key].name)
+  destination_region_name = each.value.destination_region
+  name                    = each.value.name
+}

--- a/modules/object-storage/variables.tf
+++ b/modules/object-storage/variables.tf
@@ -15,6 +15,11 @@ variable "buckets" {
       time               = string
       time_unit          = string
     }))
+    replication_policy = optional(object({
+      name                    = string
+      destination_region      = string
+      destination_bucket_name = string
+    }), null)
     optionals = map(any)
     # The followings are the keys for the optionals with defaults in brackets
     # object_events_enabled = bool - false


### PR DESCRIPTION
v2.1.2:
### New
This is a new feature in the object storage module to support replication

The is only one policy can be added to the bucket that's why it is supporting adding one policy `replication_policy` 

There is an issue opened in this repo about it
https://github.com/Binsabbar/oracle-cloud-terraform/issues/80

```
resource "oci_objectstorage_replication_policy" "bucket_replication" {
  for_each = {
    for k, v in var.buckets : k => v.replication_policy if v.replication_policy != null
  }
  bucket                  = oci_objectstorage_bucket.bucket[each.key].name
  namespace               = data.oci_objectstorage_namespace.namespace.namespace
  destination_bucket_name = lookup(each.value, "destination_bucket_name", oci_objectstorage_bucket.bucket[each.key].name)
  destination_region_name = each.value.destination_region
  name                    = each.value.name
}
```
### Fix
None

### Breaking Changes
None
