### PR TITLE
V2.11.0

### DIFF
--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -64,7 +64,9 @@ resource "oci_core_instance" "instances" {
   }
 
   lifecycle {
-    ignore_changes = ["metadata"]
+    ignore_changes = [
+      metadata.user_data
+    ]
   }
 
   create_vnic_details {

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -65,7 +65,7 @@ resource "oci_core_instance" "instances" {
 
   lifecycle {
     ignore_changes = [
-      metadata
+      metadata["user_data"]
     ]
   }
 

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -63,6 +63,10 @@ resource "oci_core_instance" "instances" {
     recovery_action             = each.value.config.availability_config.recovery_action
   }
 
+  lifecycle {
+    ignore_changes = ["metadata"]
+  }
+
   create_vnic_details {
     subnet_id                 = each.value.config.subnet.id
     assign_public_ip          = each.value.config.subnet.prohibit_public_ip_on_vnic == false

--- a/modules/instances/main.tf
+++ b/modules/instances/main.tf
@@ -65,7 +65,7 @@ resource "oci_core_instance" "instances" {
 
   lifecycle {
     ignore_changes = [
-      metadata.user_data
+      metadata
     ]
   }
 

--- a/modules/kubernetes/README.md
+++ b/modules/kubernetes/README.md
@@ -42,6 +42,7 @@ module "kubernetes" {
       node_metadata         = {}
       volume_size_in_gbs    = 500
       size                  = 2
+      defined_tags          = { "Oracle-Tags.CreatedBy" = "oke"}
       k8s_version           = "v1.18.10"
       image_id              = "ocixxxxxx.xxxxxx.xxxxx"
       labels = {
@@ -58,6 +59,7 @@ module "kubernetes" {
       node_metadata       = {}                
       volume_size_in_gbs  = 50
       size                = 4
+      defined_tags          = { "Oracle-Tags.CreatedBy" = "oke"}
       k8s_version         = "v1.18.10"
       image_id            = "ocixxxxxx.xxxxxx.xxxxx"
       flex_shape_config = {
@@ -77,6 +79,7 @@ module "kubernetes" {
       node_metadata       = {}                
       volume_size_in_gbs  = 50
       size                = 0   # this will force terraform to ignore changes to the pool size when autoscale kicks in
+      defined_tags          = { "Oracle-Tags.CreatedBy" = "oke"}
       k8s_version         = "v1.18.10"
       image_id            = "ocixxxxxx.xxxxxx.xxxxx"
       flex_shape_config = {

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -54,7 +54,7 @@ resource "oci_containerengine_node_pool" "node_pool" {
   }
   node_config_details {
     size         = each.value.size
-    defined_tags = each.value.defined_tags ? each.value.defined_tags : { "tag.Oracle-Tags.CreatedBy.value" = "oke" }
+    defined_tags = lookup(each.value.defined_tags, "defined_tags", { "tag.Oracle-Tags.CreatedBy.value" = "oke" })
     placement_configs {
       availability_domain = each.value.availability_domain
       subnet_id           = each.value.subnet_id
@@ -95,8 +95,8 @@ resource "oci_containerengine_node_pool" "node_pool_ignored_size" {
     }
   }
   node_config_details {
-    size = each.value.size
-    defined_tags = each.value.defined_tags ? each.value.defined_tags : { "tag.Oracle-Tags.CreatedBy.value" = "oke" }
+    size         = each.value.size
+    defined_tags = lookup(each.value.defined_tags, "defined_tags", { "tag.Oracle-Tags.CreatedBy.value" = "oke" })
     placement_configs {
       availability_domain = each.value.availability_domain
       subnet_id           = each.value.subnet_id

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -96,6 +96,7 @@ resource "oci_containerengine_node_pool" "node_pool_ignored_size" {
   }
   node_config_details {
     size = each.value.size
+    defined_tags = each.value.defined_tags ? each.value.defined_tags : { "tag.Oracle-Tags.CreatedBy.value" = "oke" }
     placement_configs {
       availability_domain = each.value.availability_domain
       subnet_id           = each.value.subnet_id

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -54,7 +54,7 @@ resource "oci_containerengine_node_pool" "node_pool" {
   }
   node_config_details {
     size         = each.value.size
-    defined_tags = lookup(each.value.defined_tags, "defined_tags", { "tag.Oracle-Tags.CreatedBy.value" = "oke" })
+    defined_tags = each.value.defined_tags
     placement_configs {
       availability_domain = each.value.availability_domain
       subnet_id           = each.value.subnet_id
@@ -96,7 +96,7 @@ resource "oci_containerengine_node_pool" "node_pool_ignored_size" {
   }
   node_config_details {
     size         = each.value.size
-    defined_tags = lookup(each.value.defined_tags, "defined_tags", { "tag.Oracle-Tags.CreatedBy.value" = "oke" })
+    defined_tags = each.value.defined_tags
     placement_configs {
       availability_domain = each.value.availability_domain
       subnet_id           = each.value.subnet_id

--- a/modules/kubernetes/main.tf
+++ b/modules/kubernetes/main.tf
@@ -53,7 +53,8 @@ resource "oci_containerengine_node_pool" "node_pool" {
     }
   }
   node_config_details {
-    size = each.value.size
+    size         = each.value.size
+    defined_tags = each.value.defined_tags ? each.value.defined_tags : { "tag.Oracle-Tags.CreatedBy.value" = "oke" }
     placement_configs {
       availability_domain = each.value.availability_domain
       subnet_id           = each.value.subnet_id

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -51,6 +51,7 @@ variable "node_pools" {
     volume_size_in_gbs  = number
     image_id            = string
     labels              = map(string)
+    defined_tags        = map(string)
     subnet_id           = string
     k8s_version         = string
     flex_shape_config   = map(string)
@@ -67,6 +68,7 @@ variable "node_pools" {
     volume_size_in_gbs : Size of Boot volume in GB per node
     image_id           : ocid of the image
     labels             : map of key/string values to be added to the node during creation
+    defined_tags       : Defined tags for this resource. Each key is predefined and scoped to a namespace.
     subnet_id          : ocid of the subnet to create the node in.
     k8s_version        : set the version of the node pool
     flex_shape_config  : customize number of ocpus and memory when using Flex Shape

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -51,7 +51,7 @@ variable "node_pools" {
     volume_size_in_gbs  = number
     image_id            = string
     labels              = map(string)
-    defined_tags        = map(string)
+    defined_tags        = optional(map(string))
     subnet_id           = string
     k8s_version         = string
     flex_shape_config   = map(string)

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -51,7 +51,7 @@ variable "node_pools" {
     volume_size_in_gbs  = number
     image_id            = string
     labels              = map(string)
-    defined_tags        = map(string) # optional(map(string))
+    defined_tags        = optional(map(string))
     subnet_id           = string
     k8s_version         = string
     flex_shape_config   = map(string)

--- a/modules/kubernetes/variables.tf
+++ b/modules/kubernetes/variables.tf
@@ -51,7 +51,7 @@ variable "node_pools" {
     volume_size_in_gbs  = number
     image_id            = string
     labels              = map(string)
-    defined_tags        = optional(map(string))
+    defined_tags        = map(string) # optional(map(string))
     subnet_id           = string
     k8s_version         = string
     flex_shape_config   = map(string)

--- a/modules/network-sg/README.md
+++ b/modules/network-sg/README.md
@@ -10,7 +10,6 @@ Using this module you can configure an NSG and customise rules for each group. H
 
 ## Limitations
 * IP Protocols are limited only to TCP and UDP
-* Destination or Source are limited to type `CIDR_BLOCK` (IP address only)
 * All rules are stateful.
 * No support for setting the source port (Port is limited to destination of packet)
 

--- a/modules/network-sg/README.md
+++ b/modules/network-sg/README.md
@@ -1,6 +1,7 @@
 - [Network Security Group](#network-security-group)
   - [Limitations](#limitations)
-  - [Rules and IPs](#rules-and-ips)
+  - [Rules and (IPs, network security group ids and service cidrs)](#rules-and-ips-network-security-group-ids-and-service-cidrs)
+  - [Type of Rules](#type-of-rules)
 - [Example](#example)
 
 # Network Security Group
@@ -13,9 +14,21 @@ Using this module you can configure an NSG and customise rules for each group. H
 * All rules are stateful.
 * No support for setting the source port (Port is limited to destination of packet)
 
-## Rules and IPs
+## Rules and (IPs, network security group ids and service cidrs)
 Though when using the module, a list of IPs are passed to a single rule, behind the scene, each IP results in a single rule creation. For example,
-if you pass one group that has 3 rules, and each rule contains 5 IPs, the total number of rules created by the module for the group is 15 rules.
+if you pass one group that has 3 rules, and each rule contains 5 IPs, the total number of rules created by the module for the group is 15 rules. 
+The same applies for service_cidrs and nsg_ids
+
+## Type of Rules
+The module supports all type of rules
+* IP CIDR Block
+* Service CIDR Block
+* Network Security Group ID
+  
+The default type is `CIDR_BLOCK`, however, you can use `var.network_security_groups.*.*.type` to change that. The allowed values are:
+* `CIDR_BLOCK`
+* `SERVICE_CIDR_BLOCK`
+* `NETWORK_SECURITY_GROUP`
 
 # Example
 The usage of this module is simple. You just need to create a map of groups, where each group has map of rules objects.
@@ -25,9 +38,13 @@ Creating two security groups with the following rules:
   * Rule 1: allow TCP ingress to IPs ["192.168.100.12", "192.168.100.12"] to port 9090
   * Rule 2: allow TCP ingress to IPs ["192.168.100.14", "192.168.100.16"] to port 9091
   * Rule 3: allow TCP egress from IPs ["192.168.100.12", "192.168.100.12"] to port range 8000-8002
+  * Rule 4: allow TCP egress from NSG ["ocid1.networksecuritygroup.oc1.me-jeddah-1.xxx", "ocid1.networksecuritygroup.oc1.me-jeddah-1.yyy"] to port range 8000-8002
 * Group 2:
   * Rule 1: allow UDP ingress from IPs ["192.168.200.12", "192.168.200.13"] to port 30091
   * Rule 2: allow TCP ingress from IPs ["192.168.200.12", "192.168.100.12"] to port 9000
+* Group 3:
+  * Rule 1: allow TCP ingress from NSG ["ocid1.networksecuritygroup.oc1.me-jeddah-1.xxx"] to port range 9000-9000
+  * Rule 2: allow TCP egress from service cidr ["oci-jed-objectstorage"] to port range 8000-8002
 
 ```h
 module "network_secuirty_groups" {
@@ -49,11 +66,18 @@ module "network_secuirty_groups" {
         port      = { min : 9091, max : 9091 }
         ips       = ["192.168.100.14", "192.168.100.16"]
       }
-      "rule_1" = {
+      "rule_3" = {
         direction = "EGRESS"
         protocol  = "tcp"
         port      = { min : 8000, max : 8002 }
         ips       = ["192.168.100.12", "192.168.100.12"]
+      }
+      "rule_4" = {
+        direction = "EGRESS"
+        protocol  = "tcp"
+        port      = { min : 8000, max : 8002 }
+        type      = "NETWORK_SECURITY_GROUP"
+        nsg_ids   = ["ocid1.networksecuritygroup.oc1.me-jeddah-1.xxx", "ocid1.networksecuritygroup.oc1.me-jeddah-1.yyy"]
       }
     }
     
@@ -71,7 +95,22 @@ module "network_secuirty_groups" {
         ips       = ["192.168.200.12", "192.168.100.12"]
       }
     }
-
+    "group_3" = {
+      "rule_1" = {
+        direction = "INGRESS"
+        protocol  = "tcp"
+        port      = { min : 9000, max : 9000 }
+        type      = "NETWORK_SECURITY_GROUP"
+        nsg_ids   = ["ocid1.networksecuritygroup.oc1.me-jeddah-1.xxx"]
+      }
+      "rule_2" = {
+        direction       = "EGRESS"
+        protocol        = "tcp"
+        port            = { min : 8000, max : 8002 }
+        type            = "SERVICE_CIDR_BLOCK"
+        service_cidrs   = ["oci-jed-objectstorage"]
+      }
+    }
   }
 }    
 ```

--- a/modules/network-sg/main.tf
+++ b/modules/network-sg/main.tf
@@ -52,7 +52,7 @@ resource "oci_core_network_security_group_security_rule" "ingress_rule" {
   description               = each.value.rulename
   stateless                 = false
   source                    = each.value.ip
-  source_type               = "CIDR_BLOCK"
+  source_type               = lookup(each.value, "source_type", "CIDR_BLOCK")
 
   dynamic "tcp_options" {
     for_each = each.value.protocol == "tcp" ? [each.value.ports] : []
@@ -87,7 +87,7 @@ resource "oci_core_network_security_group_security_rule" "egress_rule" {
   description               = each.value.rulename
   stateless                 = false
   destination               = each.value.ip
-  destination_type          = "CIDR_BLOCK"
+  destination_type          = lookup(each.value, "destination_type", "CIDR_BLOCK")
 
   dynamic "tcp_options" {
     for_each = each.value.protocol == "tcp" ? [each.value.ports] : []

--- a/modules/network-sg/main.tf
+++ b/modules/network-sg/main.tf
@@ -18,13 +18,14 @@ locals {
   flatten_rules = flatten([
     for group, rules in var.network_security_groups : [
       for rulename, rule in rules : [
-        for ip in rule.ips : {
+        for id in setunion(rule.ips, rule.service_cidrs, rule.nsg_ids) : {
           group     = group
           rulename  = rulename
           direction = rule.direction
           protocol  = rule.protocol
           ports     = rule.ports
-          ip        = ip
+          type      = rule.type
+          id        = id
         }
       ]
     ]
@@ -43,7 +44,7 @@ resource "oci_core_network_security_group" "security_group" {
 // Create INGRESS rules
 resource "oci_core_network_security_group_security_rule" "ingress_rule" {
   for_each = { for rule in local.flatten_rules :
-    "${rule.group}:${rule.rulename}:${rule.direction}:${rule.ip}:${rule.ports.min}:${rule.ports.max}" => rule
+    "${rule.group}:${rule.rulename}:${rule.direction}:${rule.id}:${rule.ports.min}:${rule.ports.max}" => rule
   if rule.direction == "INGRESS" }
 
   network_security_group_id = oci_core_network_security_group.security_group[each.value.group].id
@@ -51,8 +52,8 @@ resource "oci_core_network_security_group_security_rule" "ingress_rule" {
   protocol                  = lookup(local.protocols, each.value.protocol)
   description               = each.value.rulename
   stateless                 = false
-  source                    = each.value.ip
-  source_type               = lookup(each.value, "source_type", "CIDR_BLOCK")
+  source                    = each.value.id
+  source_type               = each.value.type
 
   dynamic "tcp_options" {
     for_each = each.value.protocol == "tcp" ? [each.value.ports] : []
@@ -78,7 +79,7 @@ resource "oci_core_network_security_group_security_rule" "ingress_rule" {
 // Create EGRESS rules
 resource "oci_core_network_security_group_security_rule" "egress_rule" {
   for_each = { for rule in local.flatten_rules :
-    "${rule.group}:${rule.rulename}:${rule.direction}:${rule.ip}:${rule.ports.min}:${rule.ports.max}" => rule
+    "${rule.group}:${rule.rulename}:${rule.direction}:${rule.id}:${rule.ports.min}:${rule.ports.max}" => rule
   if rule.direction == "EGRESS" }
 
   network_security_group_id = oci_core_network_security_group.security_group[each.value.group].id
@@ -86,8 +87,8 @@ resource "oci_core_network_security_group_security_rule" "egress_rule" {
   protocol                  = lookup(local.protocols, each.value.protocol)
   description               = each.value.rulename
   stateless                 = false
-  destination               = each.value.ip
-  destination_type          = lookup(each.value, "destination_type", "CIDR_BLOCK")
+  destination               = each.value.id
+  destination_type          = each.value.type
 
   dynamic "tcp_options" {
     for_each = each.value.protocol == "tcp" ? [each.value.ports] : []

--- a/modules/network-sg/variables.tf
+++ b/modules/network-sg/variables.tf
@@ -14,6 +14,8 @@ variable "network_security_groups" {
     protocol  = string
     ports     = object({ min : number, max : number })
     ips       = set(string)
+    source_type      = optional(string, "CIDR_BLOCK") # Optional, default to CIDR_BLOCK
+    destination_type = optional(string, "CIDR_BLOCK") # Optional, default to CIDR_BLOCK
   })))
 
   default = {}
@@ -39,5 +41,7 @@ variable "network_security_groups" {
         min: lower port bound 
         max: upper port bound
     ips      : list of IP addresses for the rule
+    source_type: optional; defaults to "CIDR_BLOCK" for INGRESS rules
+    destination_type: optional; defaults to "CIDR_BLOCK" for EGRESS rules
   EOL
 }

--- a/modules/network-sg/variables.tf
+++ b/modules/network-sg/variables.tf
@@ -10,15 +10,34 @@ variable "compartment_id" {
 
 variable "network_security_groups" {
   type = map(map(object({
-    direction = string
-    protocol  = string
-    ports     = object({ min : number, max : number })
-    ips       = set(string)
-    source_type      = optional(string, "CIDR_BLOCK") # Optional, default to CIDR_BLOCK
-    destination_type = optional(string, "CIDR_BLOCK") # Optional, default to CIDR_BLOCK
+    direction     = string
+    protocol      = string
+    ports         = object({ min : number, max : number })
+    type          = optional(string, "CIDR_BLOCK")
+    ips           = optional(set(string), [])
+    nsg_ids       = optional(set(string), [])
+    service_cidrs = optional(set(string), [])
   })))
 
   default = {}
+
+  validation {
+    condition = alltrue([
+      for group_name, group in var.network_security_groups :
+      alltrue([
+        for rule_name, rule in group :
+        (rule.type == "CIDR_BLOCK" && length(rule.ips) > 0 && length(rule.nsg_ids) == 0 && length(rule.service_cidrs) == 0) ||
+        (rule.type == "SERVICE_CIDR_BLOCK" && length(rule.service_cidrs) > 0 && length(rule.ips) == 0 && length(rule.nsg_ids) == 0) ||
+        (rule.type == "NETWORK_SECURITY_GROUP" && length(rule.nsg_ids) > 0 && length(rule.ips) == 0 && length(rule.service_cidrs) == 0)
+      ])
+    ])
+    error_message = <<EOF
+    if type is "CIDR_BLOCK" then `ips` must be set, and `nsg_ids` and `service_cidrs` should not be set,
+if type is "SERVICE_CIDR_BLOCK" then `service_cidrs` must be set and `nsg_ids` and `ips` is should not be set,
+if type is "NETWORK_SECURITY_GROUP" then `nsg_ids` must be set and `service_cidrs` and `ips` is should not be set
+    EOF
+  }
+
   validation {
     condition = alltrue([
       for group_name, group in var.network_security_groups :
@@ -40,8 +59,9 @@ variable "network_security_groups" {
     ports    : port object that contain the port ranege. Set both min and max to the same value if no range is needed
         min: lower port bound 
         max: upper port bound
-    ips      : list of IP addresses for the rule
-    source_type: optional; defaults to "CIDR_BLOCK" for INGRESS rules
-    destination_type: optional; defaults to "CIDR_BLOCK" for EGRESS rules
+    type (optional)          : the type of the nsg rule, default is `CIDR_BLOCK`
+    ips  (optional)          : list of IP addresses for the rule. Set if type is `CIDR_BLOCK`
+    nsg_ids (optional)       : list of network security group ids for the rule. Set if type is `NETWORK_SECURITY_GROUP`
+    service_cidrs (optional) : list of service cidr blocks for the rule. Set if type is `SERVICE_CIDR_BLOCK`
   EOL
 }

--- a/releases.md
+++ b/releases.md
@@ -18,7 +18,7 @@ resource "oci_core_instance" "instances" {
   }
   lifecycle {
     ignore_changes = [
-      metadata.user_data    <------------------------------ note this 
+      metadata   <------------------------------ note this 
     ]
   }
 }

--- a/releases.md
+++ b/releases.md
@@ -13,7 +13,9 @@ resource "oci_core_instance" "instances" {
     user_data           = lookup(each.value.optionals, "user_data", null)
   }
   lifecycle {
-    ignore_changes = ["metadata"]   <------------------------------ note this 
+    ignore_changes = [
+      metadata.user_data    <------------------------------ note this 
+    ]
   }
 }
 ```

--- a/releases.md
+++ b/releases.md
@@ -18,7 +18,7 @@ resource "oci_core_instance" "instances" {
   }
   lifecycle {
     ignore_changes = [
-      metadata   <------------------------------ note this 
+      metadata["user_data"]   <------------------------------ note this 
     ]
   }
 }

--- a/releases.md
+++ b/releases.md
@@ -1,3 +1,8 @@
+# v2.10.1:
+## **New**
+* Update the nsg variables to include `source_type` and `destination_type` in the rule configurations.
+* Update the module's variable definition to handle optional `source_type` and `destination_type`.
+* Modify resource definitions to use these new attributes and provide defaults if they are not specified.
 # v2.10.0:
 ## **New**
 * `network-sg`: change input type to support ports range in `var.network_security_groups.*.ports` variable.

--- a/releases.md
+++ b/releases.md
@@ -4,6 +4,10 @@
 * Update the module's variable definition to handle optional `source_type` and `destination_type`.
 * Modify resource definitions to use these new attributes and provide defaults if they are not specified.
 * add `ignore_changes` to `oci_core_instance` resource to update landscape config file without recreate the resource 
+None
+
+## **Fix**
+* Ignore changes made to `metadata.user_data` in any instance, since changing the value will destroy and recreate the instance. 
 ```h
 resource "oci_core_instance" "instances" {
   ...
@@ -19,9 +23,6 @@ resource "oci_core_instance" "instances" {
   }
 }
 ```
-
-## **Fix**
-None
 
 ## _**Breaking Changes**_
 None

--- a/releases.md
+++ b/releases.md
@@ -3,6 +3,28 @@
 * Update the nsg variables to include `source_type` and `destination_type` in the rule configurations.
 * Update the module's variable definition to handle optional `source_type` and `destination_type`.
 * Modify resource definitions to use these new attributes and provide defaults if they are not specified.
+* add `ignore_changes` to `oci_core_instance` resource to update landscape config file without recreate the resource 
+```h
+resource "oci_core_instance" "instances" {
+  ...
+  ...
+  metadata = {
+    ssh_authorized_keys = each.value.autherized_keys
+    user_data           = lookup(each.value.optionals, "user_data", null)
+  }
+  lifecycle {
+    ignore_changes = ["metadata"]   <------------------------------ note this 
+  }
+}
+```
+
+## **Fix**
+None
+
+## _**Breaking Changes**_
+None
+
+
 # v2.10.0:
 ## **New**
 * `network-sg`: change input type to support ports range in `var.network_security_groups.*.ports` variable.
@@ -40,25 +62,25 @@ network_security_groups = {
   * Add `capabilities` and set its value to `{}`.
 
 from:
->```h
->module "identity" {
->  ...
->  service_accounts = toset(["terraform-cli"])
->  ...
->}
->```
+```h
+module "identity" {
+  ...
+  service_accounts = toset(["terraform-cli"])
+  ...
+}
+```
 to:
->```h
->module "identity" {
->  ...
->  service_accounts = {
->    "terraform-cli" = { 
->      name = "terraform-cli", 
->      capabilities = {}
->    }
->  }
->  ...
->}
+```h
+module "identity" {
+  ...
+  service_accounts = {
+    "terraform-cli" = { 
+      name = "terraform-cli", 
+      capabilities = {}
+    }
+  }
+  ...
+}
 ```
 
 # v2.8.0:

--- a/releases.md
+++ b/releases.md
@@ -1,14 +1,18 @@
-# v2.10.1:
+# v2.11.0:
 ## **New**
-* Update the nsg variables to include `source_type` and `destination_type` in the rule configurations.
-* Update the module's variable definition to handle optional `source_type` and `destination_type`.
-* Modify resource definitions to use these new attributes and provide defaults if they are not specified.
-* add `ignore_changes` to `oci_core_instance` resource to update landscape config file without recreate the resource 
-None
-* Ability to add user defined tags for OKE nodes by using the optional variable `node_pools.*.defined_tags`
+* `network-sg`: add support for all rule types: ip cidrs, service cidrs and nsg ids.
+  * see the example in the module for how to use the new variable.
+  * the default value is `CIDR_BLOCK` to ensure backward compatibility.
+  * add new variables:
+    * `var.network_security_groups.*.*.type`
+    * `var.network_security_groups.*.*.ips`
+    * `var.network_security_groups.*.*.nsg_ids`
+    * `var.network_security_groups.*.*.service_cidrs`
+  * They are optional based on the type, if type is not set, then `var.network_security_groups.*.*.ips` becomes mandatory.
+* `kubernetes`: Ability to add user defined tags for OKE nodes by using the optional variable `node_pools.*.defined_tags`
 
 ## **Fix**
-* Ignore changes made to `metadata.user_data` in any instance, since changing the value will destroy and recreate the instance. 
+* `instances`: Ignore changes made to `metadata.user_data` in any instance, since changing the value will destroy and recreate the instance. 
 ```h
 resource "oci_core_instance" "instances" {
   ...

--- a/releases.md
+++ b/releases.md
@@ -5,6 +5,7 @@
 * Modify resource definitions to use these new attributes and provide defaults if they are not specified.
 * add `ignore_changes` to `oci_core_instance` resource to update landscape config file without recreate the resource 
 None
+* Ability to add user defined tags for OKE nodes by using the optional variable `node_pools.*.defined_tags`
 
 ## **Fix**
 * Ignore changes made to `metadata.user_data` in any instance, since changing the value will destroy and recreate the instance. 


### PR DESCRIPTION
# v2.11.0:
## **New**
* `network-sg`: add support for all rule types: ip cidrs, service cidrs and nsg ids.
  * see the example in the module for how to use the new variable.
  * the default value is `CIDR_BLOCK` to ensure backward compatibility.
  * add new variables:
    * `var.network_security_groups.*.*.type`
    * `var.network_security_groups.*.*.ips`
    * `var.network_security_groups.*.*.nsg_ids`
    * `var.network_security_groups.*.*.service_cidrs`
  * They are optional based on the type, if type is not set, then `var.network_security_groups.*.*.ips` becomes mandatory.
* `kubernetes`: Ability to add user defined tags for OKE nodes by using the optional variable `node_pools.*.defined_tags`

## **Fix**
* `instances`: Ignore changes made to `metadata.user_data` in any instance, since changing the value will destroy and recreate the instance. 
```h
resource "oci_core_instance" "instances" {
  ...
  ...
  metadata = {
    ssh_authorized_keys = each.value.autherized_keys
    user_data           = lookup(each.value.optionals, "user_data", null)
  }
  lifecycle {
    ignore_changes = [
      metadata["user_data"]   <------------------------------ note this 
    ]
  }
}
```

## _**Breaking Changes**_
None